### PR TITLE
vrt-fix-characters: Entity names with digits; --amp-entities; --unsorted; --allow-empty; literal apostrophe in structural attributes

### DIFF
--- a/vrt-tools/tests/tools/test_vrt_fix_characters.py
+++ b/vrt-tools/tests/tools/test_vrt_fix_characters.py
@@ -354,3 +354,50 @@ def test_allow_empty_field(tmpdir):
     assert out == want
     assert not err
     assert proc.returncode == 0
+
+def test_literal_apostrophe(tmpdir):
+    '''By default, keep ' literal even in attribute values.
+
+    '''
+    names = makenameline(b'word'.split())
+    send = b''.join((names,
+                     b'<text a="\'&dollar;&quot;&apos;">\n',
+                     b'\'&dollar;&quot;&apos;\n'))
+    want = b''.join((names,
+                     b'<text a="\'$&quot;\'">\n',
+                     b'\'$"\'\n'))
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--attr', 'a',
+                   '--entities' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0
+
+def test_apos(tmpdir):
+    '''With --apos, encode ' as &apos in attribute values.
+
+    '''
+    names = makenameline(b'word'.split())
+    send = b''.join((names,
+                     b'<text a="\'&dollar;&quot;&apos;">\n',
+                     b'\'&dollar;&quot;&apos;\n'))
+    want = b''.join((names,
+                     b'<text a="&apos;$&quot;&apos;">\n',
+                     b'\'$"\'\n'))
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--attr', 'a',
+                   '--entities',
+                   '--apos' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0

--- a/vrt-tools/tests/tools/test_vrt_fix_characters.py
+++ b/vrt-tools/tests/tools/test_vrt_fix_characters.py
@@ -301,3 +301,56 @@ def test_unsorted_attr(tmpdir):
     assert not err
     assert out == want
     assert proc.returncode == 0
+
+def test_replace_empty_field(tmpdir):
+    '''By default, replace empty field values with an underscore.
+
+    '''
+    # Need more than one attribute as completely empty lines are
+    # skipped
+    names = makenameline(b'word lemma'.split())
+    send = b''.join((names,
+                     b'x\t\n',
+                     b'\ty\n',
+    ))
+    want = b''.join((names,
+                     b'x\t_\n',
+                     b'_\ty\n',
+    ))
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--field', 'lemma',
+                   '--entities' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0
+
+def test_allow_empty_field(tmpdir):
+    '''With --allow-empty, keep empty field values empty, do not replace
+    with an underscore.
+
+    '''
+    # Need more than one attribute as completely empty lines are
+    # skipped
+    names = makenameline(b'word lemma'.split())
+    send = b''.join((names,
+                     b'x\t\n',
+                     b'\ty\n',
+    ))
+    want = send
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--field', 'lemma',
+                   '--allow-empty',
+                   '--entities' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0

--- a/vrt-tools/tests/tools/test_vrt_fix_characters.py
+++ b/vrt-tools/tests/tools/test_vrt_fix_characters.py
@@ -230,6 +230,32 @@ def test_entity_name_digits(tmpdir):
     assert not err
     assert proc.returncode == 0
 
+def test_amp_entities(tmpdir):
+    '''Decode mis-encoded entity references such as &amp;quot;.
+
+    '''
+    names = makenameline(b'word'.split())
+    send = b''.join(
+        (names,
+         b'<text a="&amp;quot; &amp; lt; &amp;lt; &amp;dollar; &amp;#42;">\n',
+         b'&amp;quot; &amp; lt; &amp;lt; &amp;dollar; &amp;#42;\n'))
+    want = b''.join(
+        (names,
+         b'<text a="&quot; &amp; lt; &lt; $ *">\n',
+         b'" &amp; lt; &lt; $ *\n'))
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--attr', 'a',
+                   '--entities',
+                   '--amp-entities' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0
+
 def test_eq_end_attr(tmpdir):
     '''Attribute parsing, "=" at end of value: head="VAL=" gen="WEV".
     Nothing to fix, other than normalize the order of attributes, but

--- a/vrt-tools/tests/tools/test_vrt_fix_characters.py
+++ b/vrt-tools/tests/tools/test_vrt_fix_characters.py
@@ -208,6 +208,28 @@ def test_C0_hex_data(tmpdir):
     assert not err
     assert proc.returncode == 0
 
+def test_entity_name_digits(tmpdir):
+    '''Entity name with digits, such as &frac12;.
+
+    '''
+    names = makenameline(b'word'.split())
+    send = b''.join((names,
+                     b'&frac12; kg\n'
+    ))
+    want = b''.join((names,
+                     '½ kg\n'.encode('UTF-8'),
+    ))
+    proc = Popen([ './vrt-fix-characters',
+                   '--field', 'word',
+                   '--entities' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert out == want
+    assert not err
+    assert proc.returncode == 0
+
 def test_eq_end_attr(tmpdir):
     '''Attribute parsing, "=" at end of value: head="VAL=" gen="WEV".
     Nothing to fix, other than normalize the order of attributes, but

--- a/vrt-tools/tests/tools/test_vrt_fix_characters.py
+++ b/vrt-tools/tests/tools/test_vrt_fix_characters.py
@@ -278,3 +278,26 @@ def test_eq_end_attr(tmpdir):
     assert not err
     assert out == want
     assert proc.returncode == 0
+
+def test_unsorted_attr(tmpdir):
+    '''With --unsorted, output attributes in the order they are in the
+    input.
+
+    '''
+    names = makenameline(b'word'.split())
+    send = b''.join((names,
+                     b'<text head="VAL" gen="WEV">\n'))
+    want = b''.join((names,
+                     b'<text head="VAL" gen="WEV">\n'))
+    proc = Popen([ './vrt-fix-characters',
+                   '--entities',
+                   '--attr', 'head',
+                   '--replace=identify',
+                   '--unsorted' ],
+                 stdin = PIPE,
+                 stdout = PIPE,
+                 stderr = PIPE)
+    out, err = proc.communicate(input = send, timeout = 5)
+    assert not err
+    assert out == want
+    assert proc.returncode == 0

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -127,6 +127,11 @@ def parsearguments():
                         help = '''retain input attribute order
                         (default: sort alphabetically)''')
 
+    parser.add_argument('--allow-empty',
+                        action = 'store_true',
+                        help = '''keep empty field values empty
+                        (default: replace with _)''')
+
     args = parser.parse_args()
     args.prog = parser.prog
     return args
@@ -159,6 +164,7 @@ def implement_main(args, ins, ous):
 
     anames = set(args.attributes)
     fnames = set(args.fields)
+    emptyfield = '' if args.allow_empty else '_'
     attrsort = (lambda s: s) if args.unsorted else sorted
 
     if not (anames or fnames):
@@ -195,7 +201,7 @@ def implement_main(args, ins, ous):
             record = asrecord(line)
 
             for ix in fix:
-                record[ix] = fixdata(args, record[ix])
+                record[ix] = fixdata(args, record[ix]) or emptyfield
 
             print(*record, sep = '\t', file = ous)
 
@@ -232,7 +238,7 @@ def fixdata(args, value):
     if args.reservd: value = ''.join(fixchar(args, value, catReservd))
     if args.surrogt: value = ''.join(fixchar(args, value, catSurrogt))
     # return '[{}]'.format(value) # testing
-    return value or '_'
+    return value
 
 def unbreakity(match, quote = False):
     '''Consider any &\w+; an attempted named entity (ASCII only), also

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -56,6 +56,12 @@ def parsearguments():
                         rest with an actual character (or an identifying
                         string when the character is not allowed)''')
 
+    parser.add_argument('--amp-entities',
+                        action = 'store_true',
+                        help = '''repair character entity references
+                        with the initial & encoded as &amp;, such as
+                        "&amp;quot;"; generally use with --entities''')
+
     parser.add_argument('--control',
                         action = 'store_true',
                         help = '''replace control characters with
@@ -196,6 +202,7 @@ def fixmeta(args, start, anames):
 
 def fixattr(args, value):
     '''Return fixed attribute value'''
+    if args.amp_entities: value = amp_entity.sub(r'&\1', value)
     if args.entities: value = re.sub(entitylike, unbreakity_quote, value)
     if args.identify or args.abuse: value = miscode(args, value)
     if args.control: value = ''.join(fixchar(args, value, catControl))
@@ -208,6 +215,7 @@ def fixattr(args, value):
 
 def fixdata(args, value):
     '''Return fixed positional-field value'''
+    if args.amp_entities: value = amp_entity.sub(r'&\1', value)
     if args.entities: value = re.sub(entitylike, unbreakity, value)
     if args.identify or args.abuse: value = miscode(args, value)
     if args.control: value = ''.join(fixchar(args, value, catControl))
@@ -274,6 +282,20 @@ entitylike = re.compile(R'''
       | & \# [0-9] +
       | & \# x [0-9a-f] + ) + ;
     | [&<>"']
+
+''', re.ASCII | re.IGNORECASE | re.VERBOSE)
+
+# &amp; followed by something like an entity name (or numeric
+# reference) and ; (grouped for re.sub)
+amp_entity = re.compile(R'''
+
+    &amp;
+    (
+      (?: [a-z] [a-z0-9] *
+        | \# [0-9] +
+        | \# x [0-9a-f] + )
+      ;
+    )
 
 ''', re.ASCII | re.IGNORECASE | re.VERBOSE)
 

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -132,6 +132,11 @@ def parsearguments():
                         help = '''keep empty field values empty
                         (default: replace with _)''')
 
+    parser.add_argument('--apos',
+                        action = 'store_true',
+                        help = '''encode ' as &apos; in attributes
+                        (default: keep ' literal)''')
+
     args = parser.parse_args()
     args.prog = parser.prog
     return args
@@ -162,10 +167,15 @@ def implement_main(args, ins, ous):
     def issome(line): return not line.isspace()
     def ismeta(line): return line.startswith('<')
 
+    # Is assigned to if args.apos
+    global QUOTES
+
     anames = set(args.attributes)
     fnames = set(args.fields)
     emptyfield = '' if args.allow_empty else '_'
     attrsort = (lambda s: s) if args.unsorted else sorted
+    if args.apos:
+        QUOTES = QUOTES_APOS
 
     if not (anames or fnames):
         print('{}: warning: no attributes or fields specified'
@@ -324,11 +334,21 @@ ENTITIES = {
 }
 
 QUOTES = {
-    # Two more characters are entified in meta
+    # One more character is entified in meta; ' need not, but
+    # recognize it to support --apos
     '&quot;' : '&quot;',
-    '&apos;' : '&apos;',
+    '&apos;' : "'",
     '"' : '&quot;',
-    "'" : '&apos;'
+    "'" : "'"
+}
+
+QUOTES_APOS = {
+    # With --apos (previously, always), two more characters are
+    # entified in meta
+    '&quot;' : '&quot;',
+    '&apos;' : "&apos;",
+    '"' : '&quot;',
+    "'" : "&apos;"
 }
 
 TANKEROES = {

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 # -*- mode: Python; -*-
 
+from collections import OrderedDict
 import html
 from itertools import groupby, chain
 import os, re, sys, traceback
@@ -121,6 +122,11 @@ def parsearguments():
                         with \N{BULLET}
                         ''')
 
+    parser.add_argument('--unsorted',
+                        action = 'store_true',
+                        help = '''retain input attribute order
+                        (default: sort alphabetically)''')
+
     args = parser.parse_args()
     args.prog = parser.prog
     return args
@@ -153,6 +159,7 @@ def implement_main(args, ins, ous):
 
     anames = set(args.attributes)
     fnames = set(args.fields)
+    attrsort = (lambda s: s) if args.unsorted else sorted
 
     if not (anames or fnames):
         print('{}: warning: no attributes or fields specified'
@@ -175,7 +182,8 @@ def implement_main(args, ins, ous):
                     continue
 
                 # line is a start tag and may contain attributes
-                print(fixmeta(args, line, anames), end = '', file = ous)
+                print(fixmeta(args, line, anames, attrsort),
+                      end = '', file = ous)
                 continue
 
         # groupisdata aka token lines
@@ -191,14 +199,14 @@ def implement_main(args, ins, ous):
 
             print(*record, sep = '\t', file = ous)
 
-def fixmeta(args, start, anames):
+def fixmeta(args, start, anames, attrsort):
     '''Return fixed start-tag line'''
     if not anames: return start
     tag, attrs = parsemeta(start)
     for aname in anames:
         if aname not in attrs: continue
         attrs[aname] = fixattr(args, attrs[aname])
-    return composemeta(tag, attrs, end = '\n')
+    return composemeta(tag, attrs, end = '\n', attrsort = attrsort)
 
 def fixattr(args, value):
     '''Return fixed attribute value'''
@@ -957,9 +965,9 @@ def parsemeta(start):
 
     name = name.group(1)
     rest = re.finditer(R'(\S+?)="([^"]*)"', start)
-    return name, dict(mo.groups() for mo in rest)
+    return name, OrderedDict(mo.groups() for mo in rest)
 
-def composemeta(name, attrs, end = ''):
+def composemeta(name, attrs, end = '', attrsort = sorted):
     '''Given element name and a dictionary of attributes, properly
     entified and all, construct the start tag line, sorted, spaced,
     double-quoted.
@@ -971,7 +979,7 @@ def composemeta(name, attrs, end = ''):
                                        .format(name = name,
                                                value = value) )
                                      for name, value
-                                     in sorted(attrs.items())),
+                                     in attrsort(attrs.items())),
                      end = end) )
 
 if __name__ == '__main__':

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -270,7 +270,7 @@ entitylike = re.compile(R'''
     # eventual semicolon is mandatory on an entity sequence
     # or the entity sequence will not be recognized as such
 
-    (?: & [a-z] +
+    (?: & [a-z] [a-z0-9] *
       | & \# [0-9] +
       | & \# x [0-9a-f] + ) + ;
     | [&<>"']


### PR DESCRIPTION
A couple of modifications to `vrt-fix-characters`: mostly options to make it less opinionated, with defaults as previously, except that `'` is now kept literal in (structural) attribute values by default.

The modifications in brief:

- Recognize entity names with digits, such as `&frac12;`
- Add option `--amp-entities`: Fix likely entity references with `&` encoded as `&amp;`, such as `&amp;quot;`.
- Add option `--unsorted`: Retain the original input order of (structural) attributes instead of sorting them alphabetically.
- Add option `--allow-empty`: Keep empty field (positional attribute) values intact instead of replacing them with `_`.
- Keep `'` literal (and decode `&apos;`) also in (structural) attribute values by default; specify `--apos` to encode `'` as `&apos;`.

For some more details, please see the code and commit messages.

I added tests for these modifications to `vrt-tools/tests/tools/test_vrt_fix_characters.py`.

I mostly (but not completely) tried to imitate the original coding style and use the existing terminology.