### PR TITLE
vrt-validate: Allow bare apostrophe; improve reporting suspect date/time

### DIFF
--- a/vrt-tools/test-vrt-validate
+++ b/vrt-tools/test-vrt-validate
@@ -351,9 +351,22 @@ test(tag = 'suspect-dates',
        b'</text>\n' ),
 
      expected =
-     report(('1', 'meta', 'warning', 'suspect date: datefrom of text'),
-            ('1', 'meta', 'warning', 'suspect time: timefrom of text'),
-            ('1', 'meta', 'warning', 'suspect year: year of text')))
+     report(('1', 'meta', 'error',
+             'date neither YYYYMMDD nor empty: datefrom of text'),
+            ('1', 'meta', 'error',
+             'time neither HHMMSS nor empty: timefrom of text'),
+            ('1', 'meta', 'warning',
+             'year neither YYYY nor empty: year of text')))
+
+test(tag = 'empty-dates',
+
+     document =
+     ( b'<text datefrom="" timefrom="" year="">\n'
+       b'</text>\n' ),
+
+     # No error or warning from empty dates
+     expected =
+     report())
 
 test(document =
      b'<text>\n',

--- a/vrt-tools/test-vrt-validate
+++ b/vrt-tools/test-vrt-validate
@@ -132,8 +132,9 @@ test(document =
      ( b'<foo bar="n\'">\n'
        b'</foo>' ),
 
+     # A bare apostrophe in attribute value is not an error
      expected =
-     report(('1', 'meta', 'error', 'bare apostrophe in value: bar of foo')))
+     report())
 
 test(document =
      ( b'<foo baz="" bar="">\n'

--- a/vrt-tools/vrt-validate
+++ b/vrt-tools/vrt-validate
@@ -351,16 +351,19 @@ def validateattribute(k, element, name, respond):
               .format(name, element)) )
 
 def date8(k, value, label, respond):
-    if not (len(value) == 8 and value.isdigit()):
-        respond(k, 'meta', 'warning', 'suspect date: {}'.format(label))
+    if not ((len(value) == 8 and value.isdigit()) or value == ''):
+        respond(k, 'meta', 'error',
+                'date neither YYYYMMDD nor empty: {}'.format(label))
 
 def time6(k, value, label, respond):
-    if not (len(value) == 6 and value.isdigit()):
-        respond(k, 'meta', 'warning', 'suspect time: {}'.format(label))
+    if not ((len(value) == 6 and value.isdigit()) or value == ''):
+        respond(k, 'meta', 'error',
+                'time neither HHMMSS nor empty: {}'.format(label))
 
 def year4(k, value, label, respond):
-    if not (len(value) == 4 and value.isdigit()):
-        respond(k, 'meta', 'warning', 'suspect year: {}'.format(label))
+    if not ((len(value) == 4 and value.isdigit()) or value == ''):
+        respond(k, 'meta', 'warning',
+                'year neither YYYY nor empty: {}'.format(label))
 
 def ignore(k, value, label, respond):
     pass

--- a/vrt-tools/vrt-validate
+++ b/vrt-tools/vrt-validate
@@ -338,11 +338,6 @@ def validateattributes(k, element, attributes, respond):
     for name, value in zip(names, values):
         validateattribute(k, element, name, respond)
         label = '{} of {}'.format(name, element)
-        # should check against references
-        if "'" in value:
-            respond(k, 'meta', 'error',
-                    'bare apostrophe in value: {}'
-                    .format(label))
 
         validatevalue(k, label, value, respond)
 


### PR DESCRIPTION
A couple of modifications or improvements to `vrt-validate`:

- No error or warning for a bare `'` in structural attribute values.
- Improve reporting suspect date/time values:
    - No error or warning for empty values in attributes `datefrom`/`dateto`, `timefrom`/`timeto` or `year`.
    - For `datefrom`/`dateto` and `timefrom`/`timeto`, report an error instead of a warning for an invalid value (not `YYYYMMDD`/`HHMMSS` nor empty).
    - Indicate the required format in the message.

Tests for the modifications are included in `vrt-tools/test-vrt-validate`.