### PR TITLE
`vrt-redact-long`: Redact multiple attributes, redact structural attributes, allow counting bytes

### DIFF
--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -71,17 +71,27 @@ ENTITIES = {
     b'\t' : b'{TAB}' # tab is field separator
 }
 
+ENTITY_RE_NOTAB = b'&(lt|gt|amp|quot|apos);'
+ENTITY_RE_TAB = ENTITY_RE_NOTAB + b'|\t'
+ENTITY_RE = {
+    # key: whether to encode tabs or not
+    False: re.compile(ENTITY_RE_NOTAB),
+    True: re.compile(ENTITY_RE_TAB),
+}
+
 def unentify(mo): return ENTITIES[mo.group()]
-def unescape(value):
+def unescape(value, tabs=True):
     '''Unescape the allowed character entities &lt; &gt; &amp; &quot; and
     &apos;. Should really warn of any other or something, or not? This
     is not a validator! But in that case html.unescape is good enough!
     Otherwise, there might even be bare ampersands, and who can tell
     which is which then.
 
+    Also replace tabs with {TAB} unless tabs is False.
+
     '''
 
-    return re.sub(b'&(lt|gt|amp|quot|apos);|\t', unentify, value)
+    return ENTITY_RE[tabs].sub(unentify, value)
 
 def escape(value):
     '''Escape & < > " in value as &amp; &lt; &gt; &quot; respectively.'''
@@ -95,11 +105,19 @@ def escape(value):
 STR_ENTITIES = dict((key.decode('utf-8'), val.decode('utf-8'))
                     for key, val in ENTITIES.items())
 
+STR_ENTITY_RE_NOTAB = ENTITY_RE_NOTAB.decode('utf-8')
+STR_ENTITY_RE_TAB = ENTITY_RE_TAB.decode('utf-8')
+STR_ENTITY_RE = {
+    # key: whether to encode tabs or not
+    False: re.compile(STR_ENTITY_RE_NOTAB),
+    True: re.compile(STR_ENTITY_RE_TAB),
+}
+
 def strunentify(mo): return STR_ENTITIES[mo.group()]
-def strunescape(value):
+def strunescape(value, tabs=True):
     '''As unescape but for strings instead of bytes.'''
 
-    return re.sub('&(lt|gt|amp|quot|apos);|\t', strunentify, value)
+    return STR_ENTITY_RE[tabs].sub(strunentify, value)
 
 def strescape(value):
     '''Escape & < > " in value (str) as &amp; &lt; &gt; &quot; respectively.'''

--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -82,3 +82,30 @@ def unescape(value):
     '''
 
     return re.sub(b'&(lt|gt|amp|quot|apos);|\t', unentify, value)
+
+def escape(value):
+    '''Escape & < > " in value as &amp; &lt; &gt; &quot; respectively.'''
+    return ( value
+             .replace(b'&', b'&amp;')
+             .replace(b'<', b'&lt;')
+             .replace(b'>', b'&gt;')
+             .replace(b'"', b'&quot;')
+    )
+
+STR_ENTITIES = dict((key.decode('utf-8'), val.decode('utf-8'))
+                    for key, val in ENTITIES.items())
+
+def strunentify(mo): return STR_ENTITIES[mo.group()]
+def strunescape(value):
+    '''As unescape but for strings instead of bytes.'''
+
+    return re.sub('&(lt|gt|amp|quot|apos);|\t', strunentify, value)
+
+def strescape(value):
+    '''Escape & < > " in value (str) as &amp; &lt; &gt; &quot; respectively.'''
+    return ( value
+             .replace('&', '&amp;')
+             .replace('<', '&lt;')
+             .replace('>', '&gt;')
+             .replace('"', '&quot;')
+    )

--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -109,3 +109,21 @@ def strescape(value):
              .replace('>', '&gt;')
              .replace('"', '&quot;')
     )
+
+def starttag(struct, attrs):
+    '''Start tag line for struct (bytes) with attrs (dict[bytes, bytes]).
+
+    attrs should be an OrderedDict to preserve attribute order for
+    Python versions prior to 3.8.
+
+    '''
+
+    attrstr = b' '.join(name + b'="' + val + b'"'
+                        for name, val in attrs.items())
+    return b'<' + struct + (b' ' + attrstr if attrstr else b'') + b'>\n'
+
+def strstarttag(struct, attrs):
+    '''Start tag line for struct (str) with attrs (dict[str, str]).'''
+    attrstr = ' '.join(name + '="' + val + '"'
+                       for name, val in attrs.items())
+    return '<' + struct + (' ' + attrstr if attrstr else '') + '>\n'

--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -134,6 +134,9 @@ def starttag(struct, attrs):
     attrs should be an OrderedDict to preserve attribute order for
     Python versions prior to 3.8.
 
+    This function does not escape attribute values in attrs nor check
+    their escaping, so that should be done by the caller.
+
     '''
 
     attrstr = b' '.join(name + b'="' + val + b'"'
@@ -141,7 +144,12 @@ def starttag(struct, attrs):
     return b'<' + struct + (b' ' + attrstr if attrstr else b'') + b'>\n'
 
 def strstarttag(struct, attrs):
-    '''Start tag line for struct (str) with attrs (dict[str, str]).'''
+    '''Start tag line for struct (str) with attrs (dict[str, str]).
+
+    This works the same way for strings as starttag for bytes.
+
+    '''
+
     attrstr = ' '.join(name + '="' + val + '"'
                        for name, val in attrs.items())
     return '<' + struct + (' ' + attrstr if attrstr else '') + '>\n'

--- a/vrt-tools/libvrt/structargs.py
+++ b/vrt-tools/libvrt/structargs.py
@@ -1,0 +1,102 @@
+# -*- mode: Python; -*-
+
+'''Support the parsing of command line options that pertain to
+structural attribute names (names of structures and their attributes,
+or in CWB terminology, names of structural attributes and their
+annotations).
+
+'''
+
+from argparse import ArgumentTypeError
+import re
+
+from libvrt.bad import BadData
+
+def _structattrbagtype(text, seps):
+    if re.fullmatch(f'([a-zA-Z_][a-zA-Z0-9_.]*/?|[{seps}])*', text):
+        return text.encode('UTF-8')
+    raise ArgumentTypeError(
+        'not structural attribute names: {}'.format(repr(text)))
+
+def structattrbagtype(text):
+    '''List of structural attributes separated by spaces or commas,
+    structure and its attributes separated by a colon.
+    '''
+    return _structattrbagtype(text, ', :')
+
+def structattranybagtype(text):
+    '''As structattrbagtype, but allow * to denote any.
+    '''
+    return _structattrbagtype(text, ', :*')
+
+def parsestructattrs(option, attrstype=list, valuetype=bytes):
+    '''Parse an option value that specifies structural attribute names.
+    The argument is a list of byte strings that consist of any number
+    of structural attribute names separated by any number of commas or
+    spaces (or both). A structural attribute can be specified as
+    struct_attr or struct:attr. "a:b c d" is interpreted as "a_b a_c
+    a_d", whereas "a:b c:d" is interepreted as "a_b c_d".
+
+    Returns a dict of lists (or sets) of bytes (or str):
+    {b'struct1': [b'attr1', b'attr2'], b'struct2': [b'attr3']}.
+
+    attrstype is the type of dict values: list (default) or set (or a
+    subclass of either).
+
+    valuetype is the type of names: bytes (default) or set.
+
+    An empty list is allowed. The list is not checked for duplicates.
+
+    '''
+    if issubclass(attrstype, list):
+        additem = lambda list_, item: list_.append(item)
+    elif issubclass(attrstype, set):
+        additem = lambda set_, item: set_.add(item)
+    else:
+        raise ValueError('attrstype must be (a subclass of) list or set')
+
+    if valuetype is bytes:
+        decode = lambda b: b
+    elif valuetype is str:
+        decode = lambda b: b.decode('UTF-8')
+    else:
+        raise ValueError('valuetype must be bytes or str')
+
+    structlist = (b' '.join(option)
+                  .replace(b',', b' ')
+                  # colons as separate items
+                  .replace(b':', b' : ')
+                  .split())
+
+    result = {}
+    # structure name specified before a colon
+    structprefix = None
+
+    listlen = len(structlist)
+    idx = 0
+    while idx < listlen:
+        item = structlist[idx]
+        if idx + 1 < listlen and structlist[idx + 1] == b':':
+            # next item is a colon, so this is structure name
+            structprefix = item
+            if b'_' in structprefix:
+                raise BadData('structure name may not contain underscore: {}'
+                              .format(structprefix.decode('UTF-8')))
+            idx += 2
+            continue
+        elif structprefix is None:
+            # no colon seen, so this item should be struct_attr
+            struct, _, attr = item.partition(b'_')
+            if attr == b'':
+                raise BadData('no attribute for structure: {}'
+                              .format(struct.decode('UTF-8')))
+        else:
+            # this item is attr in previously specified struct
+            struct = structprefix
+            attr = item
+        struct = decode(struct)
+        result.setdefault(struct, attrstype())
+        additem(result[struct], decode(attr))
+        idx += 1
+
+    return result

--- a/vrt-tools/libvrt/structargs.py
+++ b/vrt-tools/libvrt/structargs.py
@@ -54,7 +54,7 @@ def parsestructattrs(option, attrstype=list, valuetype=bytes):
 
     valuetype is the type of names: bytes (default) or set.
 
-    An empty list is allowed. The list is not checked for duplicates.
+    An empty list is allowed. Duplicates are not allowed.
 
     '''
     if issubclass(attrstype, list):
@@ -116,6 +116,9 @@ def parsestructattrs(option, attrstype=list, valuetype=bytes):
             attr = item
         struct = decode(struct)
         result.setdefault(struct, attrstype())
+        if attr in result[struct]:
+            raise BadData('duplicate structural attribute: {}_{}'
+                          .format(struct.decode('UTF-8'), attr.decode('UTF-8')))
         additem(result[struct], decode(attr))
         idx += 1
 

--- a/vrt-tools/test-vrt-validate
+++ b/vrt-tools/test-vrt-validate
@@ -554,6 +554,34 @@ test(tag = 'names-mismatch-record',
      report(('5', 'name', 'error', 'original number of fields: 1'),
             ('5', 'name', 'error', 'different number of names: 2')))
 
+test(tag = 'too-long-line',
+
+     document =
+     ( b'<text>\n'
+       b'<sentence>\n'
+       + (b'x' * 65533) + b'\n'
+       + (b'x' * 65534) + b'\n' +
+       b'</sentence>\n'
+       b'</text>\n' ),
+
+     expected =
+     report(('3', 'length', 'warning', 'value over 4095 bytes long: field 1'),
+            ('4', 'length', 'error', 'line over 65534 bytes long')))
+
+test(tag = 'too-long-value',
+
+     document =
+     ( b'<text a="' + (b'x' * 4095) + b'" b="' + (b'x' * 4096) + b'">\n'
+       b'<sentence>\n'
+       + (b'x' * 4095) + b'\n'
+       + (b'x' * 4096) + b'\n' +
+       b'</sentence>\n'
+       b'</text>\n' ),
+
+     expected =
+     report(('1', 'length', 'warning', 'value over 4095 bytes long: b of text'),
+            ('4', 'length', 'warning', 'value over 4095 bytes long: field 1')))
+
 print('passed: {}'.format(passed),
       'failed: {}'.format(failed),
       sep = '\n')

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -7,8 +7,8 @@ import os, re, sys, traceback
 from vrtargslib import trans_args, trans_main
 from vrtargslib import BadData, BadCode
 
-from vrtnamelib import xname, isnames, namelist, nameindices
-from vrtdatalib import asrecord, unescape, escape
+from vrtnamelib import isbinnames, binnamelist, nameindices
+from vrtdatalib import binasrecord, unescape, escape
 from libvrt.nameargs import bagtype, parsenames
 
 def parsearguments():
@@ -102,11 +102,10 @@ def parsearguments():
 def main(args, inf, ouf):
 
     if args.fields:
-        args.fields = [field.decode('utf-8')
-                       for field in parsenames(args.fields)]
+        args.fields = parsenames(args.fields)
     else:
         # default to --field word
-        args.fields = ['word']
+        args.fields = [b'word']
 
     if args.after < 0 or args.before < 0 or args.long < 1:
         raise BadData('numbers make no sense')
@@ -136,7 +135,7 @@ def main(args, inf, ouf):
 def implement_main(args, ins, ous):
 
     def issome(line): return not line.isspace()
-    def ismeta(line): return line.startswith('<')
+    def ismeta(line): return line.startswith(b'<')
 
     islike = dict(word = islikeword,
                   link = islikelink,
@@ -148,9 +147,9 @@ def implement_main(args, ins, ous):
 
         if groupismeta:
             for line in group:
-                print(line, end = '', file = ous)
-                if isnames(line):
-                    wordixs = nameindices(namelist(line), *args.fields)
+                ous.write(line)
+                if isbinnames(line):
+                    wordixs = nameindices(binnamelist(line), *args.fields)
             continue
 
         # groupisdata aka token lines
@@ -159,14 +158,14 @@ def implement_main(args, ins, ous):
             raise BadData('no names before tokens')
 
         for line in group:
-            record = asrecord(line)
+            record = binasrecord(line)
             for wordix in wordixs:
-                word = unescape(record[wordix])
+                word = unescape(record[wordix].decode('UTF-8'))
 
                 if len(word) >= args.long and islike(word):
-                    record[wordix] = escape(redact(args, word))
+                    record[wordix] = escape(redact(args, word)).encode('UTF-8')
 
-            print(*record, sep = '\t', file = ous)
+            ous.write(b'\t'.join(record) + b'\n')
 
 def redact(args, word):
     return '{}{}{}'.format(word[:args.after],
@@ -193,4 +192,4 @@ def isany(word):
     return True
 
 if __name__ == '__main__':
-    trans_main(parsearguments(), main)
+    trans_main(parsearguments(), main, in_as_text=False, out_as_text=False)

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -91,6 +91,18 @@ def parsearguments():
 
                         ''')
 
+    parser.add_argument('--bytes', action = 'store_true',
+                        help = '''
+
+                        the arguments of --long, --after and --before
+                        denote bytes instead of characters; to keep
+                        the UTF-8 encoding valid, the prefix and
+                        suffix of the redacted value may be slightly
+                        shorter than specified with --after and
+                        --before
+
+                        ''')
+
     parser.add_argument('--like', choices = [ 'word',
                                               'link',
                                               'other',
@@ -136,6 +148,9 @@ def main(args, inf, ouf):
     if args.after + args.before > args.long:
         raise BadData('after and before are already long')
 
+    if args.bytes:
+        args.text = args.text.encode('UTF-8')
+
     # *all* these exceptions should probably go to trans_main, q.v.
 
     status = 1
@@ -160,10 +175,18 @@ def implement_main(args, ins, ous):
     def issome(line): return not line.isspace()
     def ismeta(line): return line.startswith(b'<')
 
-    islike = dict(word = islikeword,
-                  link = islikelink,
-                  other = isother,
-                  any = isany) [args.like]
+    if args.bytes:
+        maybe_redact = maybe_redact_bin
+        islike = dict(word = binislikeword,
+                      link = binislikelink,
+                      other = binisother,
+                      any = isany) [args.like]
+    else:
+        maybe_redact = maybe_redact_str
+        islike = dict(word = islikeword,
+                      link = islikelink,
+                      other = isother,
+                      any = isany) [args.like]
 
     wordixs = None
     for groupismeta, group in groupby(filter(issome, ins), ismeta):
@@ -173,7 +196,7 @@ def implement_main(args, ins, ous):
                 if isbinnames(line):
                     wordixs = nameindices(binnamelist(line), *args.fields)
                 elif args.structs and line[1] not in b'/!' and b' ' in line:
-                    line = redact_struct_attrs(args, line, islike)
+                    line = redact_struct_attrs(args, line, maybe_redact, islike)
                 ous.write(line)
             continue
 
@@ -195,7 +218,7 @@ def implement_main(args, ins, ous):
 
             ous.write(b'\t'.join(record) + b'\n')
 
-def redact_struct_attrs(args, line, islike):
+def redact_struct_attrs(args, line, maybe_redact, islike):
 
     def attributes(line):
         return OrderedDict(re.findall(br'(\S+?)="([^"]*)"', line))
@@ -217,16 +240,55 @@ def redact_struct_attrs(args, line, islike):
     else:
         return line
 
-def maybe_redact(args, binvalue, islike, escape, unescape):
+def maybe_redact_str(args, binvalue, islike, escape, unescape):
     value = unescape(binvalue).decode('UTF-8')
     if len(value) >= args.long and islike(value):
         return escape(redact(args, value).encode('UTF-8'))
+    return binvalue
+
+def maybe_redact_bin(args, binvalue, islike, escape, unescape):
+    value = unescape(binvalue)
+    if len(value) >= args.long and islike(value):
+        return escape(binredact(args, value))
     return binvalue
 
 def redact(args, word):
     return '{}{}{}'.format(word[:args.after],
                            args.text,
                            word[-args.before:] if args.before else '')
+
+def binredact(args, word):
+    return (binprefix(word, args.after)
+            + args.text
+            + (binsuffix(word, args.before) if args.before else b''))
+
+def binprefix(bs, length):
+    result = bs[:length]
+    # Would the validity of a UTF-8 byte string be checked more easily
+    # and efficiently?
+    while len(result) > 0:
+        # remove additional bytes from the end until the result is
+        # valid UTF-8
+        try:
+            _ = result.decode('UTF-8')
+        except UnicodeDecodeError:
+            result = result[:-1]
+        else:
+            break
+    return result
+
+def binsuffix(bs, length):
+    result = bs[-length:]
+    while len(result) > 0:
+        # remove additional bytes from the beginning until the result
+        # is valid UTF-8
+        try:
+            _ = result.decode('UTF-8')
+        except UnicodeDecodeError:
+            result = result[1:]
+        else:
+            break
+    return result
 
 def islikeword(word):
     return re.fullmatch(R'[\w\-]+', word)
@@ -246,6 +308,23 @@ def isother(word):
 
 def isany(word):
     return True
+
+def binislikeword(word):
+    # Note that this will only take ASCII letters and digits into
+    # account, whereas islikeword recognizes Unicode letters and
+    # digits
+    return re.fullmatch(br'[\w\-]+', word)
+
+def binislikelink(word):
+    if word.startswith((b'http:', b'https:', b'ftp:')):
+        return True
+    return False
+
+def binisother(word):
+    return not (
+        binislikeword(word) or
+        binislikelink(word)
+    )
 
 if __name__ == '__main__':
     trans_main(parsearguments(), main, in_as_text=False, out_as_text=False)

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -199,7 +199,7 @@ def implement_main(args, ins, ous):
 def redact_struct_attrs(args, line, islike):
 
     def attributes(line):
-        return OrderedDict(re.findall(br'(\S+)="([^""]*)"', line))
+        return OrderedDict(re.findall(br'(\S+?)="([^"]*)"', line))
 
     struct, _, attrstr = line[1:].partition(b' ')
 

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -9,7 +9,8 @@ from vrtargslib import trans_args, trans_main
 from vrtargslib import BadData, BadCode
 
 from vrtnamelib import isbinnames, binnamelist, nameindices
-from vrtdatalib import binasrecord, unescape, escape
+from vrtdatalib import binasrecord
+from vrtdatalib import binunescape as unescape, binescape as escape
 from libvrt.nameargs import bagtype, parsenames
 from libvrt.structargs import structattrbagtype, parsestructattrs
 from libvrt.metaline import unescape as metaunescape, escape as metaescape
@@ -189,10 +190,8 @@ def implement_main(args, ins, ous):
         for line in group:
             record = binasrecord(line)
             for wordix in wordixs:
-                word = unescape(record[wordix].decode('UTF-8'))
-
-                if len(word) >= args.long and islike(word):
-                    record[wordix] = escape(redact(args, word)).encode('UTF-8')
+                record[wordix] = maybe_redact(
+                    args, record[wordix], islike, escape, unescape)
 
             ous.write(b'\t'.join(record) + b'\n')
 
@@ -210,15 +209,19 @@ def redact_struct_attrs(args, line, islike):
             attrval = attrs.get(attrname)
             if attrval is None:
                 continue
-            attrval = metaunescape(attrval).decode('UTF-8')
-            if len(attrval) >= args.long and islike(attrval):
-                attrs[attrname] = (
-                    metaescape(redact(args, attrval).encode('UTF-8')))
+            attrs[attrname] = maybe_redact(
+                args, attrval, islike, metaescape, metaunescape)
 
         return starttag(struct, attrs)
 
     else:
         return line
+
+def maybe_redact(args, binvalue, islike, escape, unescape):
+    value = unescape(binvalue).decode('UTF-8')
+    if len(value) >= args.long and islike(value):
+        return escape(redact(args, value).encode('UTF-8'))
+    return binvalue
 
 def redact(args, word):
     return '{}{}{}'.format(word[:args.after],

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -2,6 +2,7 @@
 # -*- mode: Python; -*-
 
 from itertools import groupby, chain
+from collections import OrderedDict
 import os, re, sys, traceback
 
 from vrtargslib import trans_args, trans_main
@@ -10,6 +11,9 @@ from vrtargslib import BadData, BadCode
 from vrtnamelib import isbinnames, binnamelist, nameindices
 from vrtdatalib import binasrecord, unescape, escape
 from libvrt.nameargs import bagtype, parsenames
+from libvrt.structargs import structattrbagtype, parsestructattrs
+from libvrt.metaline import unescape as metaunescape, escape as metaescape
+from libvrt.metaline import starttag
 
 def parsearguments():
     description = '''
@@ -31,7 +35,8 @@ def parsearguments():
                         help = '''
 
                         fields to redact, separate names by commas or
-                        spaces, or repeat the option (default: word)
+                        spaces, or repeat the option (default: word,
+                        or none if --struct is specified)
 
                         ''')
 
@@ -40,6 +45,20 @@ def parsearguments():
                         dest = 'fields', default = [],
                         type = bagtype, action = 'append',
                         help = '(deprecated) use --field/-f instead')
+
+    parser.add_argument('--struct', '-s',
+                        metavar = 'attr,*',
+                        dest = 'structs', default = [],
+                        type = structattrbagtype, action = 'append',
+                        help = '''
+
+                        structural attributes to redact, of the form
+                        "struct_attrname" or
+                        "struct:attrname1,attrname2" separate
+                        structure or attribute names by commas or
+                        spaces, or repeat the option (default: none)
+
+                        ''')
 
     parser.add_argument('--long', type = int, default = 70,
                         metavar = 'N',
@@ -103,9 +122,12 @@ def main(args, inf, ouf):
 
     if args.fields:
         args.fields = parsenames(args.fields)
-    else:
+    elif not args.structs:
         # default to --field word
         args.fields = [b'word']
+
+    if args.structs:
+        args.structs = parsestructattrs(args.structs, attrstype=set)
 
     if args.after < 0 or args.before < 0 or args.long < 1:
         raise BadData('numbers make no sense')
@@ -147,12 +169,19 @@ def implement_main(args, ins, ous):
 
         if groupismeta:
             for line in group:
-                ous.write(line)
                 if isbinnames(line):
                     wordixs = nameindices(binnamelist(line), *args.fields)
+                elif args.structs and line[1] not in b'/!' and b' ' in line:
+                    line = redact_struct_attrs(args, line, islike)
+                ous.write(line)
             continue
 
         # groupisdata aka token lines
+
+        if not args.fields:
+            for line in group:
+                ous.write(line)
+            continue
 
         if wordixs is None:
             raise BadData('no names before tokens')
@@ -166,6 +195,27 @@ def implement_main(args, ins, ous):
                     record[wordix] = escape(redact(args, word)).encode('UTF-8')
 
             ous.write(b'\t'.join(record) + b'\n')
+
+def redact_struct_attrs(args, line, islike):
+
+    def attributes(line):
+        return OrderedDict(re.findall(br'(\S+)="([^""]*)"', line))
+
+    struct, _, attrstr = line[1:].partition(b' ')
+
+    if struct in args.structs:
+        attrs = attributes(attrstr)
+
+        for attrname in args.structs[struct]:
+            attrval = metaunescape(attrs[attrname]).decode('UTF-8')
+            if len(attrval) >= args.long and islike(attrval):
+                attrs[attrname] = (
+                    metaescape(redact(args, attrval).encode('UTF-8')))
+
+        return starttag(struct, attrs)
+
+    else:
+        return line
 
 def redact(args, word):
     return '{}{}{}'.format(word[:args.after],

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -207,7 +207,10 @@ def redact_struct_attrs(args, line, islike):
         attrs = attributes(attrstr)
 
         for attrname in args.structs[struct]:
-            attrval = metaunescape(attrs[attrname]).decode('UTF-8')
+            attrval = attrs.get(attrname)
+            if attrval is None:
+                continue
+            attrval = metaunescape(attrval).decode('UTF-8')
             if len(attrval) >= args.long and islike(attrval):
                 attrs[attrname] = (
                     metaescape(redact(args, attrval).encode('UTF-8')))

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -310,10 +310,9 @@ def isany(word):
     return True
 
 def binislikeword(word):
-    # Note that this will only take ASCII letters and digits into
-    # account, whereas islikeword recognizes Unicode letters and
-    # digits
-    return re.fullmatch(br'[\w\-]+', word)
+    # allow Unicode letters; re.fullmatch on bytes would only take
+    # ASCII letters into account
+    return islikeword(word.decode('UTF-8'))
 
 def binislikelink(word):
     if word.startswith((b'http:', b'https:', b'ftp:')):

--- a/vrt-tools/vrt-redact-long
+++ b/vrt-tools/vrt-redact-long
@@ -7,8 +7,9 @@ import os, re, sys, traceback
 from vrtargslib import trans_args, trans_main
 from vrtargslib import BadData, BadCode
 
-from vrtnamelib import xname, isnames, namelist, nameindex
+from vrtnamelib import xname, isnames, namelist, nameindices
 from vrtdatalib import asrecord, unescape, escape
+from libvrt.nameargs import bagtype, parsenames
 
 def parsearguments():
     description = '''
@@ -23,10 +24,22 @@ def parsearguments():
 
     parser = trans_args(description = description)
 
+    parser.add_argument('--field', '-f',
+                        metavar = 'name,*',
+                        dest = 'fields', default = [],
+                        type = bagtype, action = 'append',
+                        help = '''
+
+                        fields to redact, separate names by commas or
+                        spaces, or repeat the option (default: word)
+
+                        ''')
+
     parser.add_argument('--word', '-w',
-                        metavar = 'name',
-                        type = xname, default = 'word',
-                        help = 'the field to redact (default: word)')
+                        metavar = 'name,*',
+                        dest = 'fields', default = [],
+                        type = bagtype, action = 'append',
+                        help = '(deprecated) use --field/-f instead')
 
     parser.add_argument('--long', type = int, default = 70,
                         metavar = 'N',
@@ -88,6 +101,13 @@ def parsearguments():
 
 def main(args, inf, ouf):
 
+    if args.fields:
+        args.fields = [field.decode('utf-8')
+                       for field in parsenames(args.fields)]
+    else:
+        # default to --field word
+        args.fields = ['word']
+
     if args.after < 0 or args.before < 0 or args.long < 1:
         raise BadData('numbers make no sense')
 
@@ -123,27 +143,28 @@ def implement_main(args, ins, ous):
                   other = isother,
                   any = isany) [args.like]
 
-    wordix = None
+    wordixs = None
     for groupismeta, group in groupby(filter(issome, ins), ismeta):
 
         if groupismeta:
             for line in group:
                 print(line, end = '', file = ous)
                 if isnames(line):
-                    wordix = nameindex(namelist(line), args.word)
+                    wordixs = nameindices(namelist(line), *args.fields)
             continue
 
         # groupisdata aka token lines
 
-        if wordix is None:
+        if wordixs is None:
             raise BadData('no names before tokens')
 
         for line in group:
             record = asrecord(line)
-            word = unescape(record[wordix])
+            for wordix in wordixs:
+                word = unescape(record[wordix])
 
-            if len(word) >= args.long and islike(word):
-                record[wordix] = escape(redact(args, word))
+                if len(word) >= args.long and islike(word):
+                    record[wordix] = escape(redact(args, word))
 
             print(*record, sep = '\t', file = ous)
 

--- a/vrt-tools/vrt-validate
+++ b/vrt-tools/vrt-validate
@@ -19,11 +19,17 @@ from unicodedata import category
 
 from vrtnamelib import isxname, isnames
 
+from libvrt.metaline import strunescape as unescapemeta
+
 from vrtargslib import VERSION
 
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+# CWB (or cwb-encode) limits
+VRT_LINE_MAX_BYTES = 65534
+ATTR_VALUE_MAX_BYTES = 4095
 
 class GiveUp(Exception):
     pass
@@ -70,6 +76,11 @@ def validate(k, byteline, respond):
     except UnicodeDecodeError:
         respond(k, 'code', 'error', 'not even UTF-8')
         return
+
+    if len(byteline) > VRT_LINE_MAX_BYTES:
+        # error as cwb-encode halts on longer lines
+        respond(k, 'length', 'error',
+                'line over {} bytes long'.format(VRT_LINE_MAX_BYTES))
 
     if line.endswith('\r\n'):
         respond(k, 'code', 'info', 'CR LF line terminator')
@@ -339,7 +350,7 @@ def validateattributes(k, element, attributes, respond):
         validateattribute(k, element, name, respond)
         label = '{} of {}'.format(name, element)
 
-        validatevalue(k, label, value, respond)
+        validatevalue(k, label, unescapemeta(value, tabs=False), respond)
 
         # some attributes may have particular validators
         attributevalidator.get(name, ignore)(k, value, label, respond)
@@ -452,6 +463,12 @@ def validatevalue(k, label, value, respond):
         respond(k, 'data', 'error',
                 'tab in value: {}'
                 .format(label))
+
+    if len(value.encode('UTF-8')) > ATTR_VALUE_MAX_BYTES:
+        # only warn as cwb-encode truncates longer values
+        respond(k, 'length', 'warning',
+                'value over {} bytes long: {}'
+                .format(ATTR_VALUE_MAX_BYTES, label))
 
 def validatereferences(k, line, kind, respond):
     if '&' in line:


### PR DESCRIPTION
This pull request contains a couple of additions or improvements to `vrt-redact-long` and library modules, and a modification of `vrt-validate` to recognize too long VRT lines and attribute values. The main changes are the following:

- `vrt-redact-long`:
  - Allow redacting multiple positional attributes at the same time, specified with `--field`, similarly to `vrt-keep`.
  - Add `--struct`: Specify structural attributes to be redacted.
  - Add `--bytes`: Count lengths in bytes instead of characters, preserving UTF-8 validity.
  - To improve speed, read and write in `bytes` and only convert to strings as needed.
- `vrt-validate`:
  - Error if a line is longer than 65,534 bytes (`cwb-encode` fails in error).
  - Warn if a structural or positional attribute value is longer than 4,095 bytes (`cwb-encode` truncates).
- `libvrt.metaline`:
  - Add function `escape` to encode the characters `& < > "` (in `bytes`).
  - Add functions `strunescape` and `strescape` working on strings.
  - Add functions `starttag` and `strstarttag` to construct a structure start tag form structure name and attributes.
- Add `libvrt.structargs`:
  - Parse command-line option values specifying structural attribute names similarly to `libvrt.nameargs` for positional attribute names: functions `structattrbagtype`, `structattranybagtype` and `parsestructattrs`.

Tests are unfortunately missing, except for the changes to `vrt-validate`.