### PR TITLE
Extend `vrt-add-id`: random ids, formatting, multiple elements

### DIFF
--- a/vrt-tools/libvrt/groupargs.py
+++ b/vrt-tools/libvrt/groupargs.py
@@ -1,0 +1,436 @@
+
+"""
+libvrt.groupargs
+
+Implements “grouped command-line arguments”: one option argument is
+defined as a *grouping argument* and some other arguments as *grouped
+arguments*. The values of grouped arguments are attached to the
+preceding value of the grouping argument, and the values of grouped
+arguments preceding any grouping argument are set as default values in
+cases where a grouped argument is not given a value after a grouping
+argument.
+
+This is done by defining special `argparse.Action` subclasses for the
+grouping argument and the grouped arguments.
+
+Usage example:
+
+>>> from argparse import ArgumentParser
+>>> ap = ArgumentParser()
+>>> ap.add_argument('--grp', action=grouping_arg())
+>>> ap.add_argument('--aa', action=grouped_arg(), default='a')
+>>> ap.add_argument('--bb', action=grouped_arg())
+>>> args = '--bb=b0 --grp=a --aa=a1 --bb=b1 --grp=b --aa=a2 --grp=c'
+>>> ap.parse_args(args.split())
+Namespace(grp={'a': Namespace(aa='a1', bb='b1'), 'b': Namespace(aa='a2', bb='b0'), 'c': Namespace(aa='a', bb='b0')}, aa='a', bb='b0')
+
+Non-grouped arguments can be added as usual.
+
+Note that although this module is currently in the `libvrt` package,
+it is *not* specific to VRT Tools.
+"""
+
+
+# TODO:
+# - Test interaction with various add_argument parameters, e.g.
+#   default, type, nargs
+# - Add error checking and handling: e.g., (optionally?) do not allow
+#   (or warn on) duplicate values for grouping arguments, or
+#   alternatively, use list of pairs instead of dict as grouping
+#   argument value
+
+
+from argparse import Action, Namespace, ArgumentError
+
+
+def _get_namespace_attr(namespace, name, default=None):
+    """Return value of attribute `name` in `namespace`, or `default`
+
+    If `namespace` does not contain attribute `name`, set the value of
+    `namespace.name` to `default` and return it.
+    """
+    val = getattr(namespace, name, None)
+    if val is None:
+        val = default
+        setattr(namespace, name, val)
+    return val
+
+
+class ArgumentGrouping:
+
+    """
+    Class for defining argument groupings
+
+    The public methods `grouping_arg` and `grouped_arg` return classes
+    that are subclasses of `argparse.Action` and can be used as the
+    values for the `action` argument of
+    `argparse.ArgumentParser.add_argument` (the instances of the
+    classes are callable).
+
+    In principle, you can use multiple instances of this class to have
+    multiple argument groupings for the same program, even though it
+    may be a rare use case.
+    """
+
+    def __init__(self):
+        """Create instance"""
+        # Grouping argument (argparse.Action subclass object)
+        self._grouping_arg = None
+        # Current value for the grouping argument; None if none
+        # encountered yet
+        self._grouping_val = None
+        # Grouped arguments (argparse.Action subclass objects)
+        self._grouped_args = []
+
+    def _get_grouping(self, namespace):
+        """Get the grouping argument attribute from `namespace`.
+
+        If the attribute for the grouping argument does not yet exist,
+        set it to an empty `dict`.
+        """
+        return _get_namespace_attr(namespace, self._grouping_arg.dest, {})
+
+    def _get_grouping_namespace(self, namespace):
+        """Get the namespace for the current grouping value in `namespace`.
+
+        If no grouping argument has yet been encountered, return
+        `namespace` for setting defaults.
+        """
+        if self._grouping_val:
+            return (
+                getattr(namespace, self._grouping_arg.dest, {})
+                .get(self._grouping_val))
+        else:
+            return namespace
+
+    def _add_grouped_arg(self, arg):
+        """Add `arg` as a grouped argument (`argparse.Action` object)."""
+        self._grouped_args.append(arg)
+
+    def _make_defaults(self, namespace):
+        """Return a namespace with defaults for grouped arguments.
+
+        The defaults are taken from the values of the attributes
+        corresponding to grouped arguments in `namespace`
+        """
+        defaults = Namespace()
+        for arg in self._grouped_args:
+            setattr(defaults, arg.dest, getattr(namespace, arg.dest, None))
+        return defaults
+
+    def grouping_arg(outer_self):
+        """Return a class to be used as an action for a grouping argument.
+
+        Calling this method more than once (for one `ArgumentGrouping`)
+        raises `ArgumentError`.
+        """
+        # Note that the usual `self` argument is replaced by
+        # `outer_self`, as the class definition needs to refer to it
+        # as well as use `self` in its own methods.
+        #
+        # A method returning an inner class is used so that the inner
+        # class can refer to *instance* methods and variables of the
+        # outer class. (Or would it be possible in some other way?)
+
+        class GroupingArgAction(Action):
+
+            """
+            `argparse.Action` subclass implementing a grouping argument
+            """
+
+            def __init__(self, *args, **kwargs):
+                """Initialize the action (in `ArgumentParser.add_argument`).
+
+                Set the grouping argument to `self`.
+
+                Raise `ArgumentError` if the same a grouping argument
+                has already been defined for this `ArgumentGrouping`.
+                """
+                super().__init__(*args, **kwargs)
+                if outer_self._grouping_arg is not None:
+                    raise ArgumentError(
+                        self,
+                        'Action "grouping_arg" already used for argument '
+                        + outer_self._grouping_arg.option_strings[0])
+                outer_self._grouping_arg = self
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Called when parsing the arguments and a grouping
+                argument is encountered: set the value for the
+                grouping argument and initialize its namespace with
+                defaults.
+                """
+                grouping = outer_self._get_grouping(namespace)
+                grouping[values] = outer_self._make_defaults(namespace)
+                outer_self._grouping_val = values
+
+        return GroupingArgAction
+
+    def grouped_arg(outer_self, action='store'):
+        """Return a class to be used as an action for a grouped argument.
+
+        `action` can be one of `'store'` (default), `'store_const'`,
+        `'store_true'`, `'store_false'`, `'append'`, `'append_const'`,
+        `'count'` or `'extend'`; it makes the argument behave
+        (roughly) as with the similarly-named
+        `ArgumentParser.add_argument()` action.
+
+        """
+        # The same notes about the inner class and `outer_self` apply
+        # as for `grouping_arg`.
+
+        class GroupedArgAction(Action):
+
+            """
+            `argparse.Action` subclass: base class for a grouped argument
+
+            This class cannot be used as an action itself, as it does
+            not implement `__call__`; that should be done in
+            subclasses.
+            """
+
+            def __init__(self, *args, **kwargs):
+                """Initialize the action (in `ArgumentParser.add_argument`).
+
+                Add this object as a grouping argument.
+                """
+                super().__init__(*args, **kwargs)
+                outer_self._add_grouped_arg(self)
+
+            def _set_value(self, namespace, value):
+                """Set `self.dest` to `value` in `namespace`.
+
+                Set the value of attribute `self.dest` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument has been encountered yet.
+                """
+                namespace = outer_self._get_grouping_namespace(namespace)
+                setattr(namespace, self.dest, value)
+
+            def _modify_value(self, namespace, func):
+                """Set `self.dest` to `func(self.dest)` in `namespace`.
+
+                Modify the value of attribute `self.dest` to the value
+                returned by `func` for `self.dest` in the namespace
+                for the current value of the grouping argument, or the
+                default namespace if no grouping argument has been
+                encountered yet.
+                """
+                namespace = outer_self._get_grouping_namespace(namespace)
+                value = func(getattr(namespace, self.dest, None))
+                setattr(namespace, self.dest, value)
+
+            def _append_value(self, namespace, value):
+                """Append `value` to `self.dest` in `namespace`.
+
+                Append `value` to `self.dest` (assumed to be a list)
+                in the namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument has been encountered yet.
+                """
+
+                def append(lst):
+                    """Return a copy of `lst` with `value` appended."""
+                    lst = (lst or []).copy()
+                    lst.append(value)
+                    return lst
+
+                self._modify_value(namespace, append)
+
+        class GroupedStoreAction(GroupedArgAction):
+
+            """
+            `GroupedArgAction` subclass for action `'store'`.
+            """
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Called when parsing the arguments and a grouped
+                argument is encountered: set the value of `self.dest`
+                to `values` in the namespace for the current value of
+                the grouping argument, or the default namespace if no
+                grouping argument encountered yet.
+                """
+                self._set_value(namespace, values)
+
+        class GroupedNoValueAction(GroupedArgAction):
+
+            """
+            `GroupedArgAction` subclass for option arguments without values.
+
+            Subclasses should implement `__call__`.
+            """
+
+            def __init__(self, *args, nargs=0, **kwargs):
+                """Initialize action with `nargs=0` (no value)."""
+                # See https://stackoverflow.com/a/37614126
+                super().__init__(*args, nargs=nargs, **kwargs)
+
+        class GroupedStoreConstAction(GroupedNoValueAction):
+
+            """
+            `GroupedArgAction` subclass for action `'store_const'`.
+            """
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Set the value of `self.dest` to `self.const` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._set_value(namespace, self.const)
+
+        class GroupedStoreTrueAction(GroupedNoValueAction):
+
+            """
+            `GroupedArgAction` subclass for action `'store_true'`.
+            """
+
+            def __init__(self, *args, default=False, **kwargs):
+                """Initialize action with `default=False`."""
+                super().__init__(*args, default=default, **kwargs)
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Set the value of `self.dest` to `True` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._set_value(namespace, True)
+
+        class GroupedStoreFalseAction(GroupedNoValueAction):
+
+            """
+            `GroupedArgAction` subclass for action `'store_false'`.
+            """
+
+            def __init__(self, *args, default=True, **kwargs):
+                """Initialize action with `default=True`."""
+                super().__init__(*args, default=default, **kwargs)
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Set the value of `self.dest` to `False` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._set_value(namespace, False)
+
+        class GroupedAppendAction(GroupedArgAction):
+
+            """
+            `GroupedArgAction` subclass for action `'append'`.
+            """
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Append `values` to the value of `self.dest` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._append_value(namespace, values)
+
+        class GroupedAppendConstAction(GroupedNoValueAction):
+
+            """
+            `GroupedArgAction` subclass for action `'append_const'`.
+            """
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Append `self.const` to the value of `self.dest` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._append_value(namespace, self.const)
+
+        class GroupedCountAction(GroupedNoValueAction):
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Increment the value of `self.dest` by 1 in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+                self._modify_value(namespace, lambda x: (x or 0) + 1)
+
+        class GroupedExtendAction(GroupedArgAction):
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                """Call the action (in `ArgumentParser.parse_args`)
+
+                Extend the value of `self.dest` with `values` in the
+                namespace for the current value of the grouping
+                argument, or the default namespace if no grouping
+                argument encountered yet.
+                """
+
+                def extend(lst):
+                    """Extend copy of `lst` (assumed a list) with `values`."""
+                    lst = (lst or []).copy()
+                    lst.extend(values)
+                    return lst
+
+                self._modify_value(namespace, extend)
+
+        # Map action names to classes
+        action_class = {
+            'store': GroupedStoreAction,
+            'store_const': GroupedStoreConstAction,
+            'store_true': GroupedStoreTrueAction,
+            'store_false': GroupedStoreFalseAction,
+            'append': GroupedAppendAction,
+            'append_const': GroupedAppendConstAction,
+            'count': GroupedCountAction,
+            'extend': GroupedExtendAction,
+        }
+        try:
+            return action_class[action]
+        except KeyError:
+            raise ValueError(f'unknown action "{action}"')
+
+
+# Default argument `ArgumentGrouping`, to be used in the convenience
+# functions `grouping_arg` and `grouped_arg`
+_argument_grouping = ArgumentGrouping()
+
+
+def grouping_arg():
+    """Return an `argparse.Action` subclass for a grouping argument.
+
+    This is a convenience function using a module-level instance of
+    `ArgumentGrouping`. If you need multiple grouping arguments in a
+    single program, use a different explicit `ArgumentGrouping`
+    instance for each.
+    """
+    return _argument_grouping.grouping_arg()
+
+
+def grouped_arg(action='store'):
+    """Return an `argparse.Action` subclass for a grouped argument.
+
+    `action` can be one of `'store'` (default), `'store_const'`,
+    `'store_true'`, `'store_false'`, `'append'`, `'append_const'`,
+    `'count'` or `'extend'`; it makes the argument behave (roughly) as
+    with the similarly-named `ArgumentParser.add_argument()` action.
+
+    This is a convenience function using a module-level instance of
+    `ArgumentGrouping`.
+    """
+    return _argument_grouping.grouped_arg(action)

--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -19,6 +19,16 @@ def mapping(line):
 def pairs(line):
     return re.findall(br'(\S+)="([^""]*)"', line)
 
+def element(line):
+    '''Get start or end tag element name from line (bytes).'''
+    mo = re.search(rb'\w+', line)
+    return mo.group(0) if mo else None
+
+def strelement(line):
+    '''Get start or end tag element name from line (str).'''
+    mo = re.search(r'\w+', line)
+    return mo.group(0) if mo else None
+
 def valuegetter(head, *,
                 missing, # missing value mark (safe bytes)
                 warn = True,

--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -159,3 +159,40 @@ def strstarttag(struct, attrs, sort=False):
     attrstr = ' '.join(name + '="' + val + '"'
                        for name, val in sortfn(attrs.items()))
     return '<' + struct + (' ' + attrstr if attrstr else '') + '>\n'
+
+def ismeta(line):
+    '''line (bytes) is metaline.'''
+    return line and line[0] in b'<'
+
+def strismeta(line):
+    '''line (str) is metaline.'''
+    return line and line[0] == '<'
+
+# Should the following functions call ismeta(line) (or
+# strismeta(line)) or not? Currently they don't, to reduce overhead
+# when ismeta is tested first by the caller.
+
+def isstarttag(line):
+    '''line (bytes) is a start tag, assuming ismeta(line).'''
+    return line[1] not in b'/!'
+
+def strisstarttag(line):
+    '''line (str) is a start tag, assuming strismeta(line).'''
+    return line[1] not in '/!'
+
+def isendtag(line):
+    '''line (bytes) is an end tag, assuming ismeta(line).'''
+    # This is faster than line[1].startswith(b'/')
+    return line[1] in b'/'
+
+def strisendtag(line):
+    '''line (str) is an end tag, assuming strismeta(line).'''
+    return line[1] == '/'
+
+def iscomment(line):
+    '''line (bytes) is a comment, assuming ismeta(line).'''
+    return line.startswith(b'<!--')
+
+def striscomment(line):
+    '''line (str) is a comment, assuming strismeta(line).'''
+    return line.startswith('<!--')

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -16,13 +16,14 @@ from string import Formatter
 class PartialStringFormatter(Formatter):
 
     """
-    A string formatter handling missing keys.
+    A string formatter handling missing objects.
 
     A string formatter that outputs an empty (or other specified)
-    string when a format key would cause a `KeyError`, `IndexError` or
-    `AttributeError`, or keeps the format specification intact.
+    string or keeps the replacement field intact when the object
+    specified in the replacement field is missing and would cause a
+    `KeyError`, `IndexError` or `AttributeError`, .
 
-    Adapted from
+    Adapted and extended from
     http://stackoverflow.com/questions/20248355/how-to-get-python-to-gracefully-format-none-and-non-existing-fields
     https://gist.github.com/navarroj/7689682
     """
@@ -34,39 +35,39 @@ class PartialStringFormatter(Formatter):
                               for i, s in enumerate(['{{', '}}', '{', '}']))
 
     def __init__(self, missing=''):
-        """Initialize formatter; replace missing values with `missing`.
+        """Initialize formatter; replace missing objects with `missing`.
 
-        If `missing` is `None`, keep intact format specifications
-        without a corresponding positional or keyword argument. Note
-        that this only works for whole arguments, not if an index or
-        attribute is missing; in the latter case, the format
-        specification is replaced with an empty string.
+        If `missing` is `None`, keep intact replacement fields
+        referring to a non-existent object (positional or keyword
+        argument). Note that this only works for whole arguments, not
+        if an index or attribute is missing; in the latter case, the
+        replacement field is replaced with an empty string.
         """
         super().__init__()
         self._missing = missing
 
     def vformat(self, format_string, args, kwargs):
-        """Actual formatting; handle keeping format specs for missing keys
+        """Actual formatting; handle keeping replacement fields for missing args
 
         Call `Formatter.vformat`; if `self._missing` is `None`,
-        protect formatspecs for missing keys before calling it and
-        remove protection from the result.
+        protect replacement fields without corresponding arguments
+        before calling it and remove protection from the result.
         """
         if self._missing is None:
-            format_string = self._protect_missing_formatspecs(
+            format_string = self._protect_missing_replfields(
                 format_string, len(args), kwargs.keys())
-            return self._unprotect_formatspecs(
+            return self._unprotect_replfields(
                 super().vformat(format_string, args, kwargs))
         else:
             return super().vformat(format_string, args, kwargs)
 
-    def _protect_formatspecs(self, format_string):
+    def _protect_replfields(self, format_string):
         """Protect all single and double curly brackets in `format_string`."""
         for curly, repl in self._CURLY_REPL.items():
             format_string = format_string.replace(curly, repl)
         return format_string
 
-    def _unprotect_formatspecs(self, format_string):
+    def _unprotect_replfields(self, format_string):
         """Replace curly bracket replacements in `format_string` with brackets.
 
         As the method is called after `Formatter.vformat` has replaced
@@ -77,24 +78,23 @@ class PartialStringFormatter(Formatter):
             format_string = format_string.replace(repl, curly[0])
         return format_string
 
-    def _protect_missing_formatspecs(self, format_string, args_len,
-                                     kwargs_keys):
-        """Protect format specs in `format_string` without corresponding arg.
+    def _protect_missing_replfields(self, format_string, args_len, kwargs_keys):
+        """Protect replacement fields in `format_string` with missing arg.
 
-        Protect the format specifications in `format_string` with an
+        Protect the replacement fields in `format_string` with an
         index greater than or equal to `args_len` or a key not in
         `kwargs_keys`. Note that this does *not* consider possible
-        missing indices, keys or attributes of existing fields.
+        missing indices, keys or attributes of existing arguments.
         """
-        # Unprotect those with index in args or key in kwargs
-        return self._unprotect_present_formatspecs(
-            self._protect_formatspecs(format_string), args_len, kwargs_keys)
+        # Unprotect those with index <= args_len or key in kwargs
+        return self._unprotect_present_replfields(
+            self._protect_replfields(format_string), args_len, kwargs_keys)
 
-    def _unprotect_present_formatspecs(self, format_string, args_len,
+    def _unprotect_present_replfields(self, format_string, args_len,
                                       kwargs_keys):
-        """Unprotect format specs in `format_string` with corresponding arg.
+        """Unprotect replacement fields in `format_string` with present arg.
 
-        Protect the format specifications in `format_string` with an
+        Unprotect the replacement fields in `format_string` with an
         index less than `args_len` or a key in `kwargs_keys`.
         """
         return re.sub(

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -133,3 +133,16 @@ class PartialStringFormatter(Formatter):
         if value is self._MISSING:
             value = self._missing if self._missing is not None else ''
         return super().format_field(value, spec)
+
+    def convert_field(self, value, conversion):
+        """Override `Formatter.convert_field`.
+
+        If `value` is `self._MISSING`, return it as such; otherwise,
+        call `Formatter.convert_field` on `value`.
+        """
+        if value is self._MISSING:
+            if self._missing is None:
+                return value
+            else:
+                value = self._missing
+        return super().convert_field(value, conversion)

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -29,7 +29,7 @@ class PartialStringFormatter(Formatter):
     def __init__(self, missing=''):
         """Initialize formatter; replace missing values with `missing`."""
         super().__init__()
-        self.missing = missing
+        self._missing = missing
 
     def get_field(self, field_name, args, kwargs):
         # Handle missing fields
@@ -40,6 +40,6 @@ class PartialStringFormatter(Formatter):
 
     def format_field(self, value, spec):
         if value is None:
-            return self.missing
+            return self._missing
         else:
             return super().format_field(value, spec)

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -28,6 +28,13 @@ class PartialStringFormatter(Formatter):
     https://gist.github.com/navarroj/7689682
     """
 
+    class _Missing:
+        """Empty class for a unique value to represent missing value."""
+        pass
+
+    # Unique value to represent a missing value
+    _MISSING = _Missing()
+
     # Temporary replacements of double and single curly brackets for
     # protection from replacement; the mapping needs to be ordered, as
     # double curly brackets need to be replaced before single ones
@@ -109,21 +116,20 @@ class PartialStringFormatter(Formatter):
     def get_field(self, field_name, args, kwargs):
         """Override `Formatter.get_field`.
 
-        Call `Formatter.get_field`; on error, return (`None`,
+        Call `Formatter.get_field`; on error, return (`self._MISSING`,
         `field_name`).
         """
         try:
             return super().get_field(field_name, args, kwargs)
         except (KeyError, IndexError, AttributeError):
-            return None, field_name
+            return self._MISSING, field_name
 
     def format_field(self, value, spec):
         """Override `Formatter.format_field`.
 
-        If `value` is `None`, return `self._missing`, otherwise call
-        `Formatter.format_field`
+        Call `Formatter.format_field` on `value` or `self._missing` if
+        `value` is `self._MISSING`.
         """
-        if value is None:
-            return self._missing or ''
-        else:
-            return super().format_field(value, spec)
+        if value is self._MISSING:
+            value = self._missing if self._missing is not None else ''
+        return super().format_field(value, spec)

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -9,6 +9,7 @@ string.Formatter) for various purposes.
 
 import re
 
+from collections import OrderedDict
 from string import Formatter
 
 
@@ -19,27 +20,110 @@ class PartialStringFormatter(Formatter):
 
     A string formatter that outputs an empty (or other specified)
     string when a format key would cause a `KeyError`, `IndexError` or
-    `AttributeError`.
+    `AttributeError`, or keeps the format specification intact.
 
     Adapted from
     http://stackoverflow.com/questions/20248355/how-to-get-python-to-gracefully-format-none-and-non-existing-fields
     https://gist.github.com/navarroj/7689682
     """
 
+    # Temporary replacements of double and single curly brackets for
+    # protection from replacement; the mapping needs to be ordered, as
+    # double curly brackets need to be replaced before single ones
+    _CURLY_REPL = OrderedDict((s, chr(i + 1))
+                              for i, s in enumerate(['{{', '}}', '{', '}']))
+
     def __init__(self, missing=''):
-        """Initialize formatter; replace missing values with `missing`."""
+        """Initialize formatter; replace missing values with `missing`.
+
+        If `missing` is `None`, keep intact format specifications
+        without a corresponding positional or keyword argument. Note
+        that this only works for whole arguments, not if an index or
+        attribute is missing; in the latter case, the format
+        specification is replaced with an empty string.
+        """
         super().__init__()
         self._missing = missing
 
+    def vformat(self, format_string, args, kwargs):
+        """Actual formatting; handle keeping format specs for missing keys
+
+        Call `Formatter.vformat`; if `self._missing` is `None`,
+        protect formatspecs for missing keys before calling it and
+        remove protection from the result.
+        """
+        if self._missing is None:
+            format_string = self._protect_missing_formatspecs(
+                format_string, len(args), kwargs.keys())
+            return self._unprotect_formatspecs(
+                super().vformat(format_string, args, kwargs))
+        else:
+            return super().vformat(format_string, args, kwargs)
+
+    def _protect_formatspecs(self, format_string):
+        """Protect all single and double curly brackets in `format_string`."""
+        for curly, repl in self._CURLY_REPL.items():
+            format_string = format_string.replace(curly, repl)
+        return format_string
+
+    def _unprotect_formatspecs(self, format_string):
+        """Replace curly bracket replacements in `format_string` with brackets.
+
+        As the method is called after `Formatter.vformat` has replaced
+        "{{" and "}}" with "{" and "}", this also replaces the
+        replacements of "{{" and "}}" with "{" and "}", respectively.
+        """
+        for curly, repl in self._CURLY_REPL.items():
+            format_string = format_string.replace(repl, curly[0])
+        return format_string
+
+    def _protect_missing_formatspecs(self, format_string, args_len,
+                                     kwargs_keys):
+        """Protect format specs in `format_string` without corresponding arg.
+
+        Protect the format specifications in `format_string` with an
+        index greater than or equal to `args_len` or a key not in
+        `kwargs_keys`. Note that this does *not* consider possible
+        missing indices, keys or attributes of existing fields.
+        """
+        # Unprotect those with index in args or key in kwargs
+        return self._unprotect_present_formatspecs(
+            self._protect_formatspecs(format_string), args_len, kwargs_keys)
+
+    def _unprotect_present_formatspecs(self, format_string, args_len,
+                                      kwargs_keys):
+        """Unprotect format specs in `format_string` with corresponding arg.
+
+        Protect the format specifications in `format_string` with an
+        index less than `args_len` or a key in `kwargs_keys`.
+        """
+        return re.sub(
+            (self._CURLY_REPL['{']
+             + '(('
+             + '|'.join([str(i) for i in range(args_len)] + list(kwargs_keys))
+             + r')([!:.\[].*?)?)'
+             + self._CURLY_REPL['}']),
+            r'{\1}',
+            format_string)
+
     def get_field(self, field_name, args, kwargs):
-        # Handle missing fields
+        """Override `Formatter.get_field`.
+
+        Call `Formatter.get_field`; on error, return (`None`,
+        `field_name`).
+        """
         try:
             return super().get_field(field_name, args, kwargs)
         except (KeyError, IndexError, AttributeError):
             return None, field_name
 
     def format_field(self, value, spec):
+        """Override `Formatter.format_field`.
+
+        If `value` is `None`, return `self._missing`, otherwise call
+        `Formatter.format_field`
+        """
         if value is None:
-            return self._missing
+            return self._missing or ''
         else:
             return super().format_field(value, spec)

--- a/vrt-tools/libvrt/strformatters.py
+++ b/vrt-tools/libvrt/strformatters.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from string import Formatter
 
 
-class PartialStringFormatter(Formatter):
+class PartialFormatter(Formatter):
 
     """
     A string formatter handling missing objects.

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -151,13 +151,13 @@ def parsearguments(argv, *, prog = None):
 
     group.add_argument('--type',
                        action = grouped_arg(),
-                       choices = ['counter', 'random'],
-                       default = 'counter',
+                       choices = ['random', 'counter'],
+                       default = 'random',
                        help = '''
 
-                       type of id values: "counter" for integers based
-                       on a counter, "random" for unique random
-                       integers ("counter")
+                       type of id values: "random" for unique random
+                       integers, "counter" for integers based on a
+                       counter ("random")
 
                        ''')
 
@@ -307,7 +307,7 @@ def print_verbose(args, *print_args, **kwargs):
 def set_defaults(elem, elem_args, args):
     '''Set some defaults in `elem_args` (for element `elem`) from `args`.'''
     if not elem_args.type:
-        elem_args.type = 'counter'
+        elem_args.type = 'random'
     if not elem_args.seed:
         elem_args.seed = None
     else:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -513,7 +513,7 @@ def main(args, ins, ous):
 
     # The numeric, unformatted base ids of each currently open element
     # to which ids are added
-    idnums = dict((elem, None) for elem in id_elem_names)
+    idnums = {}
     # elem_attrs keys are string values for elem, as they are used as
     # keyword argument names to formatter.format and bytes values
     # cannot be used as keyword argument names
@@ -686,7 +686,7 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr, id_counts):
             elem, args.element[elem].format, idnums)
         # Format the current id numbers for the start tags to which
         # ids were added in main
-        if idnums_curr[elem]:
+        if idnums_curr.get(elem):
             idnums[elem] = format_idnum[elem](idnums_curr[elem]).encode('UTF-8')
 
     for line in ins:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -261,7 +261,7 @@ def main(args, ins, ous):
     '''Transput VRT (bytes) in ins to VRT (bytes) in ous.'''
 
     # Names of elements to which to add ids
-    id_elem_names = [elem for elem in args.element.keys()]
+    id_elem_names = set(elem for elem in args.element.keys())
 
     # Id generators for each element
     ids = {}
@@ -305,8 +305,7 @@ def main(args, ins, ous):
                             ).encode('UTF-8'))
                     else:
                         raise BadData('element has id already')
-                    ous.write(starttag(elem, attrs, sort=args.sort))
-                    continue
+                    line = starttag(elem, attrs, sort=args.sort)
         ous.write(line)
 
 def get_idgen(args):

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -200,7 +200,6 @@ def parsearguments(argv, *, prog = None):
     group.add_argument('--max', metavar = 'number',
                        action = grouped_arg(),
                        type = intpow,
-                       default = DEFAULT_RAND_MAX,
                        help = '''
 
                        maximum random id value is number - 1; a
@@ -315,13 +314,17 @@ def set_defaults(elem, elem_args, args):
         else:
             elem_args.seed = elem_args.seed.encode('UTF-8')
         elem_args.seed = prefix + elem_args.seed
-    elem_args.format = elem_args.prefix + (
-        expand_hashes(elem_args.format, args.hash) or (
+    if elem_args.type == 'random' and not elem_args.max:
+        elem_args.max = DEFAULT_RAND_MAX
+    if elem_args.format:
+        elem_args.format = expand_hashes(elem_args.format, args.hash)
+    else:
+        elem_args.format = (
             '{id'
             + (':0' + str(get_hexvalue_len(elem_args.max)) + 'x}'
                if elem_args.type == 'random'
                else '}'))
-    )
+    elem_args.format = elem_args.prefix + elem_args.format
 
 def read_file_content(filename, max_bytes, prog='vrt-add-id'):
     '''Return up to max_bytes bytes from the beginning of file filename.

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -426,6 +426,11 @@ def check_format(fmt, elem, elem_names, elem_formatspecs, prog):
                    f' format replacement field: {msg}')
 
     repl_fields = get_format_fields(fmt)
+    if not repl_fields:
+        # The format must contain 'id' or 'idnum[elem]'
+        error(prog,
+              f'format string for element "{elem}" must contain replacement'
+              f' field "id" or "idnum[{elem}]": {fmt}')
     elemnames_re = '(?:' + '|'.join(elem_names) + ')'
     fieldnames = set()
     for repl_field in repl_fields:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -59,10 +59,9 @@ def parsearguments(argv, *, prog = None):
     fewer features. The slower one is used in following cases: (1)
     with one or more of the options --no-optimize, --force, --sort and
     --rename; (2) if an id format refers to other replacement fields
-    than {id}, {idnum[elem]}, {hash} and {hashN}; (3) if {id} or
+    than {id}, {idnum[elem]}, {hash} and {hashN}; or (3) if {id} or
     {idnum[elem]} for a certain element occurs with several different
-    format specifications; or (4) if a format specification does not
-    match the regular expression "[0-9]*[dxX]?".
+    format specifications.
 
     '''
 
@@ -545,7 +544,7 @@ def check_optimizable(elem, elem_args):
     '''
 
     # Format can contain only {id} and {idnum[*]}, optionally with
-    # simple formatting :[0-9]*[dxX]?
+    # formatting
     # idnum[elem] is the same as id
     fmt = elem_args.format.replace(
         '{idnum[{' + elem.decode('UTF-8') + '}]', '{id')
@@ -557,13 +556,6 @@ def check_optimizable(elem, elem_args):
         return (False,
                 '--format replacement field other than {id} or {idnum[elem]}: {'
                 + non_optimizable_fields[0] + '}')
-    too_complex_format = [
-        repl_field for repl_field in repl_fields
-        if not re.fullmatch(r'([^:]+)(:[0-9]*[dxX]?)?', repl_field)]
-    if too_complex_format:
-        return (False,
-                'format specification not matching "[0-9]*[dxX]?": {'
-                + too_complex_format[0] + '}')
 
     # Check that the same idnum[elem] is not used with different
     # formats; use the keys of OrderedDict to preserve the input order
@@ -773,9 +765,9 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr, id_counts):
                     # f'{id}' seems to be faster than str(id), at
                     # least in Python 3.10.12
                     func_text = (
-                        'lambda id: f"{id'
+                        'lambda id: f"""{id'
                         + (':' + formatspec if formatspec else '')
-                        + '}"')
+                        + '}"""')
                     # print(func_text)
                     idnum_format_func = eval(func_text)
                 else:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -112,25 +112,15 @@ def parsearguments(argv, *, prog = None):
 
                        ''')
 
-    group.add_argument('--counter',
-                       action = grouped_arg('store_const'),
-                       dest = 'type',
-                       const = 'counter',
+    group.add_argument('--type',
+                       action = grouped_arg(),
+                       choices = ['counter', 'random'],
+                       default = 'counter',
                        help = '''
 
-                       id values are integers based on a counter (the
-                       default)
-
-                       ''')
-
-    group.add_argument('--random',
-                       action = grouped_arg('store_const'),
-                       dest = 'type',
-                       const = 'random',
-                       help = '''
-
-                       id values are unique random integers (overrides
-                       --counter)
+                       type of id values: "counter" for integers based
+                       on a counter, "random" for unique random
+                       integers ("counter")
 
                        ''')
 
@@ -177,9 +167,9 @@ def parsearguments(argv, *, prog = None):
                        element elem to which ids are added or an
                        enclosing element; supports Python
                        str.format-style formatting (default: with
-                       --counter, "{id}"; with --random, "{id:0*x}"
-                       where * is the minimum number of hex digits to
-                       represent the maximum value)
+                       --type=counter, "{id}"; with --type=random,
+                       "{id:0*x}" where * is the minimum number of hex
+                       digits to represent the maximum value)
 
                        ''')
 

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -51,116 +51,6 @@ def parsearguments(argv, *, prog = None):
 
     parser = transput_args(description = description)
 
-    parser.add_argument('--element', metavar = 'name',
-                        action = grouping_arg(),
-                        type = nametype,
-                        # Default for --element is set only later, to
-                        # make it work correctly with grouping_arg
-                        # default = b'sentence',
-                        help = '''
-
-                        name of the VRT element to use; if no element
-                        is specified, use "sentence"; if multiple
-                        elements are specified, the options below
-                        apply to the element after which they are
-                        specified, or become defaults for all elements
-                        if specified before any --element
-
-                        ''')
-
-    parser.add_argument('--id', dest = 'idn', metavar = 'name',
-                        action = grouped_arg(),
-                        type = nametype,
-                        default = b'id',
-                        help = '''
-
-                        name of the "id" attribute ("id")
-
-                        ''')
-
-    parser.add_argument('--counter',
-                        action = grouped_arg('store_const'),
-                        dest = 'type',
-                        const = 'counter',
-                        help = '''
-
-                        id values are integers based on a counter (the
-                        default)
-
-                        ''')
-
-    parser.add_argument('--random',
-                        action = grouped_arg('store_const'),
-                        dest = 'type',
-                        const = 'random',
-                        help = '''
-
-                        id values are unique random integers (overrides
-                        --counter)
-
-                       ''')
-
-    parser.add_argument('--seed', metavar = 'string',
-                        action = grouped_arg(),
-                        default = '',
-                        help = '''
-
-                        random number generator seed for random ids
-                        (default: "" = non-reproducible)
-
-                        ''')
-
-    parser.add_argument('--start', metavar = 'number',
-                        action = grouped_arg(),
-                        type = int,
-                        default = 1,
-                        help = '''
-
-                        initial value for the counter (1)
-
-                        ''')
-
-    parser.add_argument('--end', metavar = 'number',
-                        action = grouped_arg(),
-                        type = intpow,
-                        default = DEFAULT_RAND_END,
-                        help = '''
-
-                        maximum random id value is number - 1; a
-                        non-negative integer, hexadecimal if prefixed
-                        with "0x", or n^k for n to the power of k
-                        (default: 2^32)
-
-                        ''')
-
-    parser.add_argument('--format', metavar = 'format',
-                        action = grouped_arg(),
-                        help = '''
-
-                        format string for id, with "{id}" replaced
-                        with the id value and "{elem[attr]}" with the
-                        value of the existing attribute attr in the
-                        element elem to which ids are added or an
-                        enclosing element; supports Python
-                        str.format-style formatting (default: with
-                        --counter, "{id}"; with --random, "{id:0*x}"
-                        where * is the minimum number of hex digits to
-                        represent the maximum value)
-
-                        ''')
-
-    parser.add_argument('--prefix', metavar = 'affix',
-                        action = grouped_arg(),
-                        type = affix,
-                        default = '',
-                        help = '''
-
-                        additional prefix text to each formatted id,
-                        prepended to the format string specified with
-                        --format ("")
-
-                        ''')
-
     parser.add_argument('--hash', metavar = 'string',
                         action = 'append',
                         help = '''
@@ -186,6 +76,124 @@ def parsearguments(argv, *, prog = None):
                         (default: keep input order)
 
                         ''')
+
+    parser.add_argument('--element', metavar = 'name',
+                        action = grouping_arg(),
+                        type = nametype,
+                        # Default for --element is set only later, to
+                        # make it work correctly with grouping_arg
+                        # default = b'sentence',
+                        help = '''
+
+                        name of the VRT element to use; can be
+                        repeated; if no --element is specified, use
+                        "sentence"
+
+                        ''')
+
+    group = parser.add_argument_group(
+        'element-specific options',
+        '''
+
+        The following options can be specified multiple times: each
+        occurrence applies to the --element after which it is
+        specified. If an option is specified before any --element, it
+        becomes the default for all elements.
+
+        ''')
+
+    group.add_argument('--id', dest = 'idn', metavar = 'name',
+                       action = grouped_arg(),
+                       type = nametype,
+                       default = b'id',
+                       help = '''
+
+                       name of the "id" attribute ("id")
+
+                       ''')
+
+    group.add_argument('--counter',
+                       action = grouped_arg('store_const'),
+                       dest = 'type',
+                       const = 'counter',
+                       help = '''
+
+                       id values are integers based on a counter (the
+                       default)
+
+                       ''')
+
+    group.add_argument('--random',
+                       action = grouped_arg('store_const'),
+                       dest = 'type',
+                       const = 'random',
+                       help = '''
+
+                       id values are unique random integers (overrides
+                       --counter)
+
+                       ''')
+
+    group.add_argument('--seed', metavar = 'string',
+                       action = grouped_arg(),
+                       default = '',
+                       help = '''
+
+                       random number generator seed for random ids
+                       (default: "" = non-reproducible)
+
+                       ''')
+
+    group.add_argument('--start', metavar = 'number',
+                       action = grouped_arg(),
+                       type = int,
+                       default = 1,
+                       help = '''
+
+                       initial value for the counter (1)
+
+                       ''')
+
+    group.add_argument('--end', metavar = 'number',
+                       action = grouped_arg(),
+                       type = intpow,
+                       default = DEFAULT_RAND_END,
+                       help = '''
+
+                       maximum random id value is number - 1; a
+                       non-negative integer, hexadecimal if prefixed
+                       with "0x", or n^k for n to the power of k
+                       (default: 2^32)
+
+                       ''')
+
+    group.add_argument('--format', metavar = 'format',
+                       action = grouped_arg(),
+                       help = '''
+
+                       format string for id, with "{id}" replaced
+                       with the id value and "{elem[attr]}" with the
+                       value of the existing attribute attr in the
+                       element elem to which ids are added or an
+                       enclosing element; supports Python
+                       str.format-style formatting (default: with
+                       --counter, "{id}"; with --random, "{id:0*x}"
+                       where * is the minimum number of hex digits to
+                       represent the maximum value)
+
+                       ''')
+
+    group.add_argument('--prefix', metavar = 'affix',
+                       action = grouped_arg(),
+                       type = affix,
+                       default = '',
+                       help = '''
+
+                       additional prefix text to each formatted id,
+                       prepended to the format string specified with
+                       --format ("")
+
+                       ''')
 
     args = parser.parse_args()
     # If no elements have been specified, make all options pertain to

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -15,7 +15,7 @@ from libvrt.args import transput_args
 from libvrt.metaname import nametype # need checked
 from libvrt.metaline import mapping, starttag
 
-from libvrt.strformatters import PartialStringFormatter
+from libvrt.strformatters import PartialFormatter
 from libvrt.strformatters import BytesFormatter
 
 # Default maximum random id value (DEFAULT_RAND_END - 1)
@@ -203,7 +203,7 @@ def expand_hashes(format_, strlist):
     hashvals['hash'] = hashvals['hash1']
 
     # This keeps the non-hash format specs in format_ intact
-    return PartialStringFormatter(None).format(format_, **hashvals)
+    return PartialFormatter(None).format(format_, **hashvals)
 
 def main(args, ins, ous):
     '''Transput VRT (bytes) in ins to VRT (bytes) in ous.'''

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -569,9 +569,10 @@ def main(args, ins, ous):
                                     **elem_attrs
                                 ).encode('UTF-8'))
                         except KeyError as e:
+                            estr = str(e).replace('b\'', '\'')
                             raise BadData(
                                 'format replacement field '
-                                f'{elem_args.format}: key {e} not found')
+                                f'{elem_args.format}: key {estr} not found')
                         if verbose:
                             id_counts[elem] += 1
                     else:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -690,6 +690,7 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr, id_counts):
         idnum_format_func = None
         # Split fmt to replacement fields and fixed strings
         parts = re.findall(r'{.*?}|[^{]+', fmt)
+        elem = elem.decode('UTF-8')
 
         for i, part in enumerate(parts):
             if part[0] == '{':
@@ -700,7 +701,7 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr, id_counts):
                 part, _, formatspec = part.partition(':')
                 if part in ('id', f'idnum[{elem}]'):
                     # Id num for the current element
-                    part = f'idnums[{elem}]'
+                    part = f'idnums[b"{elem}"]'
                     # f'{id}' seems to be faster than str(id), at
                     # least in Python 3.10.12
                     func_text = (

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -735,7 +735,7 @@ def rename_attr(attrs, old, new):
     attribute name does not exist in attrs.
 
     Effectively adds new with the value of old and deletes old, so the
-    order attributes in of attrs changes.
+    order of attributes in attrs changes.
     '''
 
     if b'{}' in new:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -114,7 +114,7 @@ def parsearguments(argv, *, prog = None):
 
                         ''')
 
-    parser.add_argument('--element', metavar = 'name',
+    parser.add_argument('--element', '-e', metavar = 'name',
                         action = grouping_arg(),
                         type = nametype,
                         # Default for --element is set only later, to

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -33,7 +33,7 @@ def affix(arg):
 def intpow(arg):
     '''argparse argument type check for non-negative integer, 0x... or n^k'''
     if re.fullmatch('[0-9]+|0x[0-9A-Fa-f]+', arg):
-        return int(arg, base=0)
+        return int(arg, base = 0)
     elif re.fullmatch(r'[0-9]+\^[0-9]+', arg):
         base, exp = arg.split('^')
         return pow(int(base), int(exp))
@@ -347,14 +347,19 @@ def main(args, ins, ous):
     # The names of elements whose contents have been checked for
     # optimization
     checked_elems = set()
+
     for line in ins:
+
         if ismeta(line):
             elem = element(line)
             elem_s = elem.decode('UTF-8')
+
             if isendtag(line):
                 del elem_attrs[elem_s]
+
             elif isstarttag(line):
                 attrs = elem_attrs[elem_s] = mapping(line)
+
                 if elem in id_elem_names:
                     # Element-specific options
                     elem_args = args.element[elem]
@@ -384,14 +389,14 @@ def main(args, ins, ous):
                         attrs[elem_args.idn] = (
                             formatter.format(
                                 elem_args.format,
-                                id=id,
-                                this=attrs,
-                                idnum=idnums,
+                                id = id,
+                                this = attrs,
+                                idnum = idnums,
                                 **elem_attrs
                             ).encode('UTF-8'))
                     else:
                         raise BadData('element has id already')
-                    line = starttag(elem, attrs, sort=args.sort)
+                    line = starttag(elem, attrs, sort = args.sort)
 
         ous.write(line)
 
@@ -505,7 +510,7 @@ def get_idgen(args):
             args.seed += '1'
         return randint_uniq(args.end, args.seed)
 
-def randint_uniq(end, seed=None):
+def randint_uniq(end, seed = None):
     '''Generator for unique random integers in [0, end[ with seed.'''
 
     # Values already generated

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -689,6 +689,11 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr, id_counts):
         if idnums_curr.get(elem):
             idnums[elem] = format_idnum[elem](idnums_curr[elem]).encode('UTF-8')
 
+    # NOTE: If the format of elem2 refers to idnum[elem1] of enclosing
+    # elem1 and the current elem2 is not enclosed in elem1 but elem1
+    # has occurred previously in the input, the previous value of
+    # idnum[elem1] is used. To raise an error, we should also handle
+    # element end tags.
     for line in ins:
         if ismeta(line) and isstarttag(line):
             elem = element(line)

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -23,8 +23,8 @@ from libvrt.metaline import (
 from libvrt.strformatters import PartialFormatter
 from libvrt.strformatters import SubstitutingBytesFormatter
 
-# Default maximum random id value (DEFAULT_RAND_END - 1)
-DEFAULT_RAND_END = pow(2, 32)
+# Default maximum random id value (DEFAULT_RAND_MAX - 1)
+DEFAULT_RAND_MAX = pow(2, 32)
 
 # Maximum number of bytes to read from a random seed file
 MAX_SEED_BYTES = pow(2, 20)
@@ -197,10 +197,10 @@ def parsearguments(argv, *, prog = None):
 
                        ''')
 
-    group.add_argument('--end', metavar = 'number',
+    group.add_argument('--max', metavar = 'number',
                        action = grouped_arg(),
                        type = intpow,
-                       default = DEFAULT_RAND_END,
+                       default = DEFAULT_RAND_MAX,
                        help = '''
 
                        maximum random id value is number - 1; a
@@ -318,7 +318,7 @@ def set_defaults(elem, elem_args, args):
     elem_args.format = elem_args.prefix + (
         expand_hashes(elem_args.format, args.hash) or (
             '{id'
-            + (':0' + str(get_hexvalue_len(elem_args.end)) + 'x}'
+            + (':0' + str(get_hexvalue_len(elem_args.max)) + 'x}'
                if elem_args.type == 'random'
                else '}'))
     )
@@ -706,7 +706,7 @@ def get_idgen(args):
         )
 
     else:
-        return randint_uniq(args.end, args.seed)
+        return randint_uniq(args.max, args.seed)
 
 def randint_uniq(end, seed = None):
     '''Generator for unique random integers in [0, end[ with seed.'''
@@ -714,7 +714,7 @@ def randint_uniq(end, seed = None):
     # Values already generated
     used = set()
     rnd = random.Random(seed)
-    errmsg = f'more than {end} elements encountered; please increase --end'
+    errmsg = f'more than {end} elements encountered; please increase --max'
 
     while True:
         if len(used) >= end:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -103,7 +103,7 @@ def parsearguments(argv, *, prog = None):
     parser.add_argument('--force', action = 'store_true',
                         help = '''
 
-                        overwriting an existing id
+                        overwrite an existing id
 
                         ''')
 
@@ -219,35 +219,39 @@ def parsearguments(argv, *, prog = None):
                        action = grouped_arg(),
                        help = '''
 
-                       format string for id, with Python
+                       Format string for id, with Python
                        str.format-style formatting: "{id}" is replaced
                        with the integer id value, "{idnum[elem]}" with
                        the integer id value for element elem, and
                        "{elem[attr]}" with the string value of the
                        existing attribute attr in the current or an
                        enclosing element (the current element can also
-                       be referred to as "this"); "{id}" and
-                       "{idnum[elem]}" without format specification
-                       implicitly use the default format
+                       be referred to as "this").
+
+                       "{id}" and "{idnum[elem]}" without a format
+                       specification implicitly use the default format
                        specification; "{idnum[elem]}" referred to in
                        the format string of another element uses the
                        format specification specified for element
-                       elem; formatting string values is extended with
+                       elem.
+
+                       Formatting string values is extended with
                        regular expression substitutions:
                        "{elem[attr]/regexp/subst/}" is "{elem[attr]}"
                        with all matches of regexp replaced with subst;
                        subst may refer to groups in regexp as \\N,
                        \\g<N> or \\g<name>; multiple substitutions are
-                       separated by commas, semicolons or spaces
-                       (default: with --type=counter, "{id:d}"; with
+                       separated by commas, semicolons or spaces.
+
+                       (Default: with --type=counter, "{id:d}"; with
                        --type=random, "{id:0*x}" where * is the
                        minimum number of hex digits to represent the
-                       maximum value; if no --element nor --format is
+                       maximum value. If no --element nor --format is
                        specified, "t-{hash:.8}-{id}" for text,
                        "p-{hash:.8}-{idnum[text]}-{id}" for paragraph
                        and "s-{hash:.8}-{idnum[text]}-{id}" for
                        sentence, with a random hash if no --hash is
-                       specified)
+                       specified.)
 
                        ''')
 

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -161,23 +161,23 @@ def parsearguments(argv, *, prog = None):
                        action = grouped_arg(),
                        help = '''
 
-                       format string for id, with "{id}" replaced with
-                       the id value and "{elem[attr]}" with the value
-                       of the existing attribute attr in the element
-                       elem to which ids are added or an enclosing
-                       element (the current element can also be
-                       referred to as "this"); supports Python
-                       str.format-style formatting, extended with
-                       regular expression substitutions, so that
-                       "{elem[attr]/regexp/subst/}" is "{elem[attr]}"
-                       with all matches of regexp replaced with subst;
-                       subst may refer to groups in regexp as \\N,
-                       \\g<N> or \\g<name>; multiple substitutions are
-                       separated by commas, semicolons or spaces
-                       (default: with --type=counter, "{id}"; with
-                       --type=random, "{id:0*x}" where * is the
-                       minimum number of hex digits to represent the
-                       maximum value)
+                       format string for id, with Python
+                       str.format-style formatting: "{id}" is replaced
+                       with the id value, "{idnum[elem]}" with the id
+                       value for element elem, and "{elem[attr]}" with
+                       the value of the existing attribute attr in the
+                       current or an enclosing element (the current
+                       element can also be referred to as "this");
+                       formatting is extended with regular expression
+                       substitutions: "{elem[attr]/regexp/subst/}" is
+                       "{elem[attr]}" with all matches of regexp
+                       replaced with subst; subst may refer to groups
+                       in regexp as \\N, \\g<N> or \\g<name>; multiple
+                       substitutions are separated by commas,
+                       semicolons or spaces (default: with
+                       --type=counter, "{id}"; with --type=random,
+                       "{id:0*x}" where * is the minimum number of hex
+                       digits to represent the maximum value)
 
                        ''')
 
@@ -270,6 +270,9 @@ def main(args, ins, ous):
 
     formatter = SubstitutingBytesFormatter()
 
+    # The numeric, unformatted base ids of each currently open element
+    # to which ids are added
+    idnums = dict((elem, None) for elem in id_elem_names)
     # elem_attrs keys are string values for elem, as they are used as
     # keyword argument names to formatter.format and bytes values
     # cannot be used as keyword argument names
@@ -290,11 +293,14 @@ def main(args, ins, ous):
                             or elem_args.idn not in attrs):
                         if elem_args.rename and elem_args.idn in attrs:
                             rename_attr(attrs, elem_args.idn, elem_args.rename)
+                        id = next(ids[elem])
+                        idnums[elem] = id
                         attrs[elem_args.idn] = (
                             formatter.format(
                                 elem_args.format,
-                                id=next(ids[elem]),
+                                id=id,
                                 this=attrs,
+                                idnum=idnums,
                                 **elem_attrs
                             ).encode('UTF-8'))
                     else:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -73,6 +73,7 @@ def parsearguments(argv, *, prog = None):
 
                         make "{hash}" in the id format string refer to
                         the hex digest of the SHA-1 hash of string; if
+                        string is empty, generate a random hash; if
                         the option is repeated, "{hashN}" refers to
                         the Nth value
 
@@ -600,6 +601,8 @@ def expand_hashes(format_, strlist):
 
     {hash} is an alias for {hash1}.
 
+    If strlist[N] is empty, use a random string (bytes).
+
     As hash values are constant for all ids, it suffices to expand
     them once in the id format string, avoiding the need to re-expand
     them for each id.
@@ -608,9 +611,11 @@ def expand_hashes(format_, strlist):
     if not strlist:
         return format_
 
+    rnd = random.Random()
     hashvals = {}
     for i, s in enumerate(strlist):
-        hashvals[f'hash{i + 1}'] = sha1(s.encode('UTF-8')).hexdigest()
+        s = s.encode('UTF-8') if s else rnd.randbytes(1024)
+        hashvals[f'hash{i + 1}'] = sha1(s).hexdigest()
     hashvals['hash'] = hashvals['hash1']
 
     # This keeps the non-hash format specs in format_ intact

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -161,11 +161,12 @@ def parsearguments(argv, *, prog = None):
                        action = grouped_arg(),
                        help = '''
 
-                       format string for id, with "{id}" replaced
-                       with the id value and "{elem[attr]}" with the
-                       value of the existing attribute attr in the
-                       element elem to which ids are added or an
-                       enclosing element; supports Python
+                       format string for id, with "{id}" replaced with
+                       the id value and "{elem[attr]}" with the value
+                       of the existing attribute attr in the element
+                       elem to which ids are added or an enclosing
+                       element (the current element can also be
+                       referred to as "this"); supports Python
                        str.format-style formatting (default: with
                        --type=counter, "{id}"; with --type=random,
                        "{id:0*x}" where * is the minimum number of hex
@@ -265,6 +266,7 @@ def main(args, ins, ous):
                             formatter.format(
                                 elem_args.format,
                                 id=next(ids[elem]),
+                                this=attrs,
                                 **elem_attrs
                             ).encode('UTF-8'))
                     else:

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -61,7 +61,7 @@ def parsearguments(argv, *, prog = None):
     than {id}, {idnum[elem]}, {hash} and {hashN}; (3) if {id} or
     {idnum[elem]} for a certain element occurs with several different
     format specifications; or (4) if a format specification does not
-    match the regular expression "0?[0-9][dxX]".
+    match the regular expression "[0-9]*[dxX]?".
 
     '''
 
@@ -348,12 +348,12 @@ def is_optimizable(elem, elem_args):
         return False
 
     # Format can contain only {id} and {idnum[*]}, optionally with
-    # simple formatting :0?[0-9][dxX]
+    # simple formatting :[0-9]*[dxX]?
     fmt = elem_args.format.replace('{{', '').replace('}}', '')
     # idnum[elem] is the same as id
     fmt = fmt.replace('{idnum[{' + elem.decode('UTF-8') + '}]', '{id')
     repl_fields = re.findall(r'\{(.*?)\}', fmt)
-    if not all(re.fullmatch(r'(id|idnum\[[a-z0-9]+\])(:0?[0-9]+[dxX])?',
+    if not all(re.fullmatch(r'(id|idnum\[[a-z0-9]+\])(:[0-9]*[dxX]?)?',
                             repl_field)
                for repl_field in repl_fields):
         return False
@@ -493,7 +493,7 @@ def fast_main(args, ins, ous, id_elem_names, ids, idnums_curr):
     {idnum[elem]} (and {hash*}, which are expanded earlier), nor if
     the same {id} or {idnum[elem]} occur with different format
     specifications, nor if a format specification does not match the
-    regular expression "0?[0-9][dxX]". These should be checked in
+    regular expression "[0-9]*[dxX]?". These should be checked in
     advance.
     '''
 

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -19,7 +19,7 @@ from libvrt.metaline import (
     mapping, starttag, ismeta, isstarttag, isendtag, element)
 
 from libvrt.strformatters import PartialFormatter
-from libvrt.strformatters import BytesFormatter
+from libvrt.strformatters import SubstitutingBytesFormatter
 
 # Default maximum random id value (DEFAULT_RAND_END - 1)
 DEFAULT_RAND_END = pow(2, 32)
@@ -167,10 +167,17 @@ def parsearguments(argv, *, prog = None):
                        elem to which ids are added or an enclosing
                        element (the current element can also be
                        referred to as "this"); supports Python
-                       str.format-style formatting (default: with
-                       --type=counter, "{id}"; with --type=random,
-                       "{id:0*x}" where * is the minimum number of hex
-                       digits to represent the maximum value)
+                       str.format-style formatting, extended with
+                       regular expression substitutions, so that
+                       "{elem[attr]/regexp/subst/}" is "{elem[attr]}"
+                       with all matches of regexp replaced with subst;
+                       subst may refer to groups in regexp as \\N,
+                       \\g<N> or \\g<name>; multiple substitutions are
+                       separated by commas, semicolons or spaces
+                       (default: with --type=counter, "{id}"; with
+                       --type=random, "{id:0*x}" where * is the
+                       minimum number of hex digits to represent the
+                       maximum value)
 
                        ''')
 
@@ -261,7 +268,7 @@ def main(args, ins, ous):
     for elem in id_elem_names:
         ids[elem] = get_idgen(args.element[elem])
 
-    formatter = BytesFormatter()
+    formatter = SubstitutingBytesFormatter()
 
     # elem_attrs keys are string values for elem, as they are used as
     # keyword argument names to formatter.format and bytes values

--- a/vrt-tools/tests/README.md
+++ b/vrt-tools/tests/README.md
@@ -89,8 +89,8 @@ test case:
         be used, but each file must be specified only once.
     -   `transform`: transform the base content of standard input and
         all input files according to the specified options
-        (`list(dict)` or `dict`). Currently the following options are
-        supported:
+        (`list(dict)`, `dict`, `str` or `int`). Currently the
+        following options are supported:
 		-   `prepend`: content to prepend to `value` (`str`); `None`
             is treated as an empty string, `int` returned intact
 		-   `append`: content to append to `value` (`str`); `None`
@@ -141,6 +141,9 @@ test case:
         of each other. If the value is a list of single-item
         dictionaries, the transformations are applied in the list
         order, each transformation to the output of the preceding one.
+        If the value is a plain `str` or `int`, or a list contains a
+        plain `str` or `int` (or `None`), it is treated as replacing
+        the value completely (implicit `set-value`).
 
 	`cmdline`, `stdin`, `file:FNAME` and the values under `files` may
     be either plain strings containing the content, or dicts of one or
@@ -279,19 +282,22 @@ test case:
 
     The `dict`s in the list can contain the following keys:
 
-    -   `input`: Transformations to be added to input files and
-        command line (`transform`).
-    -   `output-expected`: Transformations to be added to output
-        (`transform-expected`).
-    -   `output-actual`: Transformations to be added to output
-        (`transform-actual`).
+    -   `name`: descriptive name for the transformation group
+        (`str`)
+    -   `input`: transformations to be added to input files and
+        command line (`transform`)
+    -   `output-expected`: transformations to be added to output
+        (`transform-expected`)
+    -   `output-actual`: transformations to be added to output
+        (`transform-actual`)
 
-    The value of each of these is a `dict` with keys corresponding to
-    (transformable) items in the `input` and `output` `dict`s of a
-    test (files, `cmdline`, `stdin`, `stdout`, `stderr`, `returncode`)
-    and values transformation `dict`s or lists of them, as for
-    `transform` of `input` items and `transform-expected` and
-    `transform-actual` of `output` items.
+    The value of `input`, `output-expected` and `output-actual` is a
+    `dict` with keys corresponding to (transformable) items in the
+    `input` and `output` `dict`s of a test (files, `cmdline`, `stdin`,
+    `stdout`, `stderr`, `returncode`) and values corresponding to
+    transformation `dict`s or lists of them, as for `transform` of
+    `input` items and `transform-expected` and `transform-actual` of
+    `output` items.
 
     Grouped transformations are applied to values after global,
     file-specific and test-specific ones.

--- a/vrt-tools/tests/libvrt/test_groupargs.py
+++ b/vrt-tools/tests/libvrt/test_groupargs.py
@@ -1,0 +1,290 @@
+
+"""
+test_groupargs.py
+
+Pytest tests for libvrt.groupargs.
+"""
+
+
+import pytest
+
+from argparse import ArgumentParser, ArgumentError
+
+from libvrt.groupargs import ArgumentGrouping, grouping_arg, grouped_arg
+
+
+class TestArgumentGrouping:
+
+    """Tests for ArgumentGrouping"""
+
+    def test_argument_grouping_basic(self):
+        """Test ArgumentGrouping basic functionality."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg())
+        ap.add_argument('--bb', action=ag.grouped_arg())
+        argstr = '--grp=a --aa=a1 --bb=b1 --grp=b --aa=a2'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 'a1'
+        assert args.grp['a'].bb == 'b1'
+        assert args.grp['b'].aa == 'a2'
+        assert args.grp['b'].bb == None
+
+    def test_argument_grouping_defaults(self):
+        """Test ArgumentGrouping default values."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg(), default='a')
+        ap.add_argument('--bb', action=ag.grouped_arg())
+        ap.add_argument('--cc', action=ag.grouped_arg())
+        argstr = '--bb=b0 --grp=a --aa=a1 --bb=b1 --grp=b --aa=a2 --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 'a1'
+        assert args.grp['a'].bb == 'b1'
+        assert args.grp['a'].cc == None
+        assert args.grp['b'].aa == 'a2'
+        assert args.grp['b'].bb == 'b0'
+        assert args.grp['b'].cc == None
+        assert args.grp['c'].aa == 'a'
+        assert args.grp['c'].bb == 'b0'
+        assert args.grp['c'].cc == None
+
+    def test_non_grouped_args(self):
+        """Test non-grouped arguments."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg())
+        ap.add_argument('--xx')
+        argstr = '--grp=a --aa=a1 --grp=b --aa=a2 --xx=x'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 'a1'
+        assert args.grp['b'].aa == 'a2'
+        assert args.xx == 'x'
+        for key in ['a', 'b']:
+            with pytest.raises(AttributeError):
+                assert args.grp[key].x
+
+    def test_two_argument_groupings(self):
+        """Test two ArgumentGroupings."""
+        ap = ArgumentParser()
+        ag1 = ArgumentGrouping()
+        ag2 = ArgumentGrouping()
+        ap.add_argument('--g1', action=ag1.grouping_arg())
+        ap.add_argument('--aa', action=ag1.grouped_arg())
+        ap.add_argument('--bb', action=ag1.grouped_arg())
+        ap.add_argument('--g2', action=ag2.grouping_arg())
+        ap.add_argument('--cc', action=ag2.grouped_arg())
+        ap.add_argument('--dd', action=ag2.grouped_arg())
+        argstr = '--g1=a --aa=a1 --g2=c --bb=b1 --cc=c1 --g1=b --g2=d --cc=c2 --dd=d2 --aa=a2'
+        args = ap.parse_args(argstr.split())
+        assert args.g1
+        assert args.g1['a'].aa == 'a1'
+        assert args.g1['a'].bb == 'b1'
+        assert args.g1['b'].aa == 'a2'
+        assert args.g1['b'].bb == None
+        assert args.g2
+        assert args.g2['c'].cc == 'c1'
+        assert args.g2['c'].dd == None
+        assert args.g2['d'].cc == 'c2'
+        assert args.g2['d'].dd == 'd2'
+
+    def test_two_grouping_arg_error(self):
+        """Test that two grouping_arg calls raise ArgumentError."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        with pytest.raises(
+                ArgumentError,
+                match='Action "grouping_arg" already used for argument --grp'):
+            ap.add_argument('--grp2', action=ag.grouping_arg())
+
+    def test_convenience_funcs_simple(self):
+        """Test ArgumentGrouping convenience functions."""
+        ap = ArgumentParser()
+        ap.add_argument('--grp', action=grouping_arg())
+        ap.add_argument('--aa', action=grouped_arg(), default='a')
+        ap.add_argument('--bb', action=grouped_arg())
+        argstr = '--bb=b0 --grp=a --aa=a1 --bb=b1 --grp=b --aa=a2 --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 'a1'
+        assert args.grp['a'].bb == 'b1'
+        assert args.grp['b'].aa == 'a2'
+        assert args.grp['b'].bb == 'b0'
+        assert args.grp['c'].aa == 'a'
+        assert args.grp['c'].bb == 'b0'
+
+    def test_convenience_funcs_grouping_arg_already_used(self):
+        """Test that convenience functions support only one grouping."""
+        ap = ArgumentParser()
+        with pytest.raises(
+                ArgumentError,
+                match='Action "grouping_arg" already used for argument --grp'):
+            ap.add_argument('--grp2', action=grouping_arg())
+
+
+class TestArgumentGroupingGroupedActions:
+
+    """Tests for ArgumentGrouping, grouped_arg with an explicit action."""
+
+    def test_explicit_store(self):
+        """Test action "store" (default)."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg('store'), default='a')
+        ap.add_argument('--bb', action=ag.grouped_arg('store'))
+        ap.add_argument('--cc', action=ag.grouped_arg('store'))
+        argstr = '--bb=b0 --grp=a --aa=a1 --bb=b1 --grp=b --aa=a2 --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 'a1'
+        assert args.grp['a'].bb == 'b1'
+        assert args.grp['a'].cc == None
+        assert args.grp['b'].aa == 'a2'
+        assert args.grp['b'].bb == 'b0'
+        assert args.grp['b'].cc == None
+        assert args.grp['c'].aa == 'a'
+        assert args.grp['c'].bb == 'b0'
+        assert args.grp['c'].cc == None
+
+    def test_store_const(self):
+        """Test action "store_const"."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', dest='x', const='aa',
+                        action=ag.grouped_arg('store_const'))
+        ap.add_argument('--bb', dest='x', const='bb',
+                        action=ag.grouped_arg('store_const'))
+        ap.add_argument('--cc', dest='x', const='cc',
+                        action=ag.grouped_arg('store_const'))
+        argstr = '--bb --grp=a --aa --bb --grp=b --aa --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].x == 'bb'
+        assert args.grp['b'].x == 'aa'
+        assert args.grp['c'].x == 'bb'
+
+    @pytest.mark.parametrize(
+        "action,default,stored",
+        [('store_true', False, True),
+         ('store_false', True, False)]
+    )
+    def test_store_true_false(self, action, default, stored):
+        """Test actions "store_true" and "store_false" (parametrized)."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg(action))
+        ap.add_argument('--bb', action=ag.grouped_arg(action))
+        ap.add_argument('--cc', action=ag.grouped_arg(action))
+        argstr = '--bb --grp=a --aa --bb --grp=b --aa --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == stored
+        assert args.grp['a'].bb == stored
+        assert args.grp['a'].cc == default
+        assert args.grp['b'].aa == stored
+        assert args.grp['b'].bb == stored
+        assert args.grp['b'].cc == default
+        assert args.grp['c'].aa == default
+        assert args.grp['c'].bb == stored
+        assert args.grp['c'].cc == default
+
+    def test_append(self):
+        """Test action "append"."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg('append'), default=['a'])
+        ap.add_argument('--bb', action=ag.grouped_arg('append'))
+        ap.add_argument('--cc', action=ag.grouped_arg('append'))
+        argstr = '--bb=b0 --grp=a --aa=a1 --bb=b1 --grp=b --aa=a2 --aa=a3 --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == ['a', 'a1']
+        assert args.grp['a'].bb == ['b0', 'b1']
+        assert args.grp['a'].cc == None
+        assert args.grp['b'].aa == ['a', 'a2', 'a3']
+        assert args.grp['b'].bb == ['b0']
+        assert args.grp['b'].cc == None
+        assert args.grp['c'].aa == ['a']
+        assert args.grp['c'].bb == ['b0']
+        assert args.grp['c'].cc == None
+
+    def test_append_const(self):
+        """Test action "append_const"."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', dest='x', const='aa',
+                        action=ag.grouped_arg('append_const'))
+        ap.add_argument('--bb', dest='x', const='bb',
+                        action=ag.grouped_arg('append_const'))
+        ap.add_argument('--cc', dest='x', const='cc',
+                        action=ag.grouped_arg('append_const'))
+        argstr = '--bb --grp=a --aa --bb --grp=b --aa --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].x == ['bb', 'aa', 'bb']
+        assert args.grp['b'].x == ['bb', 'aa']
+        assert args.grp['c'].x == ['bb']
+
+    def test_count(self):
+        """Test action "count"."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg('count'), default=1)
+        ap.add_argument('--bb', action=ag.grouped_arg('count'))
+        ap.add_argument('--cc', action=ag.grouped_arg('count'))
+        argstr = '--bb --grp=a --aa --bb --grp=b --aa --aa --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == 2
+        assert args.grp['a'].bb == 2
+        assert args.grp['a'].cc == None
+        assert args.grp['b'].aa == 3
+        assert args.grp['b'].bb == 1
+        assert args.grp['b'].cc == None
+        assert args.grp['c'].aa == 1
+        assert args.grp['c'].bb == 1
+        assert args.grp['c'].cc == None
+
+    def test_extend(self):
+        """Test action "extend"."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        ap.add_argument('--aa', action=ag.grouped_arg('extend'), default=['a'], nargs='+')
+        ap.add_argument('--bb', action=ag.grouped_arg('extend'))
+        ap.add_argument('--cc', action=ag.grouped_arg('extend'))
+        argstr = '--bb b0 --grp=a --aa a1 --bb b1 --grp=b --aa a2 a3 --grp=c'
+        args = ap.parse_args(argstr.split())
+        assert args.grp
+        assert args.grp['a'].aa == ['a', 'a1']
+        assert args.grp['a'].bb == ['b', '0', 'b', '1']
+        assert args.grp['a'].cc == None
+        assert args.grp['b'].aa == ['a', 'a2', 'a3']
+        assert args.grp['b'].bb == ['b', '0']
+        assert args.grp['b'].cc == None
+        assert args.grp['c'].aa == ['a']
+        assert args.grp['c'].bb == ['b', '0']
+        assert args.grp['c'].cc == None
+
+    def test_unknown_action(self):
+        """Test unknown action name."""
+        ap = ArgumentParser()
+        ag = ArgumentGrouping()
+        ap.add_argument('--grp', action=ag.grouping_arg())
+        with pytest.raises(
+                ValueError,
+                match='unknown action "unknown"'):
+            ap.add_argument('--aa', action=ag.grouped_arg('unknown'))

--- a/vrt-tools/tests/libvrt/test_metaline.py
+++ b/vrt-tools/tests/libvrt/test_metaline.py
@@ -1,0 +1,66 @@
+
+"""
+test_metaline.py
+
+Pytest tests for libvrt.metaline.
+"""
+
+
+import pytest
+
+import libvrt.metaline as ml
+
+
+@pytest.mark.parametrize('line,expected',
+                         [('a', False),
+                          ('&lt;', False),
+                          (' <', False),
+                          ('<starttag>', True),
+                          ('<starttag attr="a">', True),
+                          ('</endtag>', True),
+                          ('<!-- comment -->', True)])
+class TestIsmeta:
+
+    """Tests for functions ismeta and strismeta."""
+
+    def test_ismeta(self, line, expected):
+        """Test ismeta()."""
+        assert ml.ismeta(line.encode('UTF-8') + b'\n') == expected
+
+    def test_strismeta(self, line, expected):
+        """Test strismeta()."""
+        assert ml.strismeta(line + '\n') == expected
+
+
+@pytest.mark.parametrize('line,starttag,endtag,comment',
+                         [('<starttag>', True, False, False),
+                          ('<starttag attr="a">', True, False, False),
+                          ('</endtag>', False, True, False),
+                          ('<!-- comment -->', False, False, True)])
+class TestMetalineType:
+
+    """Tests for functions testing the type of a meta line."""
+
+    def test_isstarttag(self, line, starttag, endtag, comment):
+        """Test isstarttag()."""
+        assert ml.isstarttag(line.encode('UTF-8') + b'\n') == starttag
+
+    def test_strisstarttag(self, line, starttag, endtag, comment):
+        """Test strisstarttag()."""
+        assert ml.strisstarttag(line + '\n') == starttag
+
+    def test_isendtag(self, line, starttag, endtag, comment):
+        """Test isendtag()."""
+        assert ml.isendtag(line.encode('UTF-8') + b'\n') == endtag
+
+    def test_strisendtag(self, line, starttag, endtag, comment):
+        """Test strisendtag()."""
+        assert ml.strisendtag(line + '\n') == endtag
+
+    def test_iscomment(self, line, starttag, endtag, comment):
+        """Test iscomment()."""
+        assert ml.iscomment(line.encode('UTF-8') + b'\n') == comment
+
+    def test_striscomment(self, line, starttag, endtag, comment):
+        """Test striscomment()."""
+        assert ml.striscomment(line + '\n') == comment

--- a/vrt-tools/tests/libvrt/test_metaline.py
+++ b/vrt-tools/tests/libvrt/test_metaline.py
@@ -11,6 +11,53 @@ import pytest
 import libvrt.metaline as ml
 
 
+class TestElement:
+
+    """Tests for vrtlib.metaline functions .element, strelement."""
+
+    @pytest.mark.parametrize('input,expected',
+                             [(b'<elem>', b'elem'),
+                              (b'<elem2>', b'elem2')])
+    def test_element_starttag_without_attrs(self, input, expected):
+        """Test element() for a start tag without attributes."""
+        assert ml.element(input) == expected
+
+    @pytest.mark.parametrize('input,expected',
+                             [(b'<elem a="a">', b'elem'),
+                              (b'<elem2  b="b" c="c">', b'elem2')])
+    def test_element_starttag_with_attrs(self, input, expected):
+        """Test element() for a start tag with attributes."""
+        assert ml.element(input) == expected
+
+    @pytest.mark.parametrize('input,expected',
+                             [(b'</elem>', b'elem'),
+                              (b'</elem2>', b'elem2')])
+    def test_element_endtag(self, input, expected):
+        """Test element() for an end tag."""
+        assert ml.element(input) == expected
+
+    @pytest.mark.parametrize('input,expected',
+                             [('<elem>', 'elem'),
+                              ('<elem2>', 'elem2')])
+    def test_strelement_starttag_without_attrs(self, input, expected):
+        """Test strelement() for a start tag without attributes."""
+        assert ml.strelement(input) == expected
+
+    @pytest.mark.parametrize('input,expected',
+                             [('<elem a="a">', 'elem'),
+                              ('<elem2  b="b" c="c">', 'elem2')])
+    def test_strelement_starttag_with_attrs(self, input, expected):
+        """Test strelement() for a start tag with attributes."""
+        assert ml.strelement(input) == expected
+
+    @pytest.mark.parametrize('input,expected',
+                             [('</elem>', 'elem'),
+                              ('</elem2>', 'elem2')])
+    def test_strelement_endtag(self, input, expected):
+        """Test strelement() for an end tag."""
+        assert ml.strelement(input) == expected
+
+
 @pytest.mark.parametrize('line,expected',
                          [('a', False),
                           ('&lt;', False),

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -1,0 +1,70 @@
+
+"""
+test_strformatters.py
+
+Pytest tests for libvrt.strformatters.
+"""
+
+
+import pytest
+
+from libvrt.strformatters import PartialStringFormatter
+
+
+class Namespace:
+
+    """Empty class to be used as a namespace."""
+
+    pass
+
+
+class TestPartialStringFormatter:
+
+    """Tests for PartialStringFormatter"""
+
+    def test_all_keys_exist(self):
+        """Test a case in which all format keys exist."""
+        psf = PartialStringFormatter()
+        ns = Namespace()
+        ns.x = 4
+        result = psf.format('{0}{1} a {a} b {b} c {c[0]} d {d[a]} e {ns.x}',
+                            'x', 'y', a=1, b=2, c=[0], d={'a': 3}, ns=ns)
+        assert result == 'xy a 1 b 2 c 0 d 3 e 4'
+
+    def test_missing_arg(self):
+        """Test a case with missing positional argument."""
+        psf = PartialStringFormatter()
+        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1, b=2)
+        assert result == 'x a 1 b 2'
+
+    def test_missing_kwarg(self):
+        """Test a case with missing keyword argument."""
+        psf = PartialStringFormatter()
+        result = psf.format('{0}{1} a {a} b {b}', 'x', 'y', a=1)
+        assert result == 'xy a 1 b '
+
+    def test_missing_list_item(self):
+        """Test a case with a missing item in a list."""
+        psf = PartialStringFormatter()
+        result = psf.format('{a[0]} {a[1]}', a=[0])
+        assert result == '0 '
+
+    def test_missing_dict_key(self):
+        """Test a case with a missing key in a dict."""
+        psf = PartialStringFormatter()
+        result = psf.format('{a[a]} {a[b]}', a={'a': 0})
+        assert result == '0 '
+
+    def test_missing_attr(self):
+        """Test a case with a missing attribute."""
+        psf = PartialStringFormatter()
+        ns = Namespace()
+        ns.a = 0
+        result = psf.format('{ns.a} {ns.b}', ns=ns)
+        assert result == '0 '
+
+    def test_alternative_replacement_value(self):
+        """Test a case with an alternative replacement value for missing."""
+        psf = PartialStringFormatter('*')
+        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
+        assert result == 'x* a 1 b *'

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -269,6 +269,18 @@ class TestSubstitutingFormatters:
                           ns=Namespace(a=b'ccddee'))
         assert result == 'bbbbcc aaccc xxddee'
 
+    def test_empty_substitution(self, formatfn):
+        """Test empty substitution (removal)."""
+        result = formatfn('{0/a//} {a/b+//}',
+                          b'aabbcc', a=b'aabbcc')
+        assert result == 'bbcc aacc'
+
+    def test_empty_regexp(self, formatfn):
+        """Test empty regexp (insertion everywhere)."""
+        result = formatfn('{0//+/} {a//x/}',
+                          b'aabbcc', a=b'aabbcc')
+        assert result == '+a+a+b+b+c+c+ xaxaxbxbxcxcx'
+
     def test_substitution_with_format_spec(self, formatfn):
         """Test substitution with a format specification."""
         result = formatfn('|{0/a/b/:8s}|{a/b+/c/:@^10s}|',
@@ -286,6 +298,12 @@ class TestSubstitutingFormatters:
         result = formatfn('{0 /a/b/, /b+/cc/ ; /c/dd/ /e/f//f/g/}',
                           b'aabbccddeeff')
         assert result == 'ddddddddddgggg'
+
+    def test_multiple_substitutions_with_empty(self, formatfn):
+        """Test multiple substitutions, including empty (removal)."""
+        result = formatfn('{0 /a/b/, /b+// ; /c/dd/ /e/f//f//}',
+                          b'aabbccddeeff')
+        assert result == 'dddddd'
 
     def test_substitution_groups(self, formatfn):
         """Test substitution with groups."""

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -20,7 +20,10 @@ class Namespace:
 
     """Empty class to be used as a namespace."""
 
-    pass
+    def __init__(self, **kwargs):
+        """Set instance attributes from kwargs."""
+        for key, val in kwargs.items():
+            setattr(self, key, val)
 
 
 def decode(val):
@@ -46,10 +49,9 @@ class TestPartialFormatter:
     def test_all_keys_exist(self):
         """Test a case in which all format keys exist."""
         pf = PartialFormatter()
-        ns = Namespace()
-        ns.x = 4
         result = pf.format('{0}{1} a {a} b {b} c {c[0]} d {d[a]} e {ns.x}',
-                           'x', 'y', a=1, b=2, c=[0], d={'a': 3}, ns=ns)
+                           'x', 'y', a=1, b=2, c=[0], d={'a': 3},
+                           ns=Namespace(x=4))
         assert result == 'xy a 1 b 2 c 0 d 3 e 4'
 
     def test_missing_arg(self):
@@ -79,9 +81,7 @@ class TestPartialFormatter:
     def test_missing_attr(self):
         """Test a case with a missing attribute."""
         pf = PartialFormatter()
-        ns = Namespace()
-        ns.a = 0
-        result = pf.format('{ns.a} {ns.b}', ns=ns)
+        result = pf.format('{ns.a} {ns.b}', ns=Namespace(a=0))
         assert result == '0 '
 
     def test_missing_args_none(self):
@@ -184,9 +184,7 @@ class TestPartialFormatter:
     def test_keep_replfields_missing_attr(self):
         """Test keeping a replacement field with a missing attribute."""
         pf = PartialFormatter(None)
-        ns = Namespace()
-        ns.a = 0
-        result = pf.format('{ns.a} {ns.b}', ns=ns)
+        result = pf.format('{ns.a} {ns.b}', ns=Namespace(a=0))
         assert result == '0 '
 
 
@@ -197,8 +195,7 @@ class TestBytesFormatter:
     def test_format_strings(self):
         """Test formatting strings with BytesFormatter."""
         bf = BytesFormatter()
-        ns = Namespace()
-        ns.a = '2'
+        ns = Namespace(a='2')
         result = bf.format('|{0}|{1[0]}|{2.a}|{a}|{b[a]}|{ns.a}|',
                            0, [1, 2], ns, a='a', b={'a': 'b'}, ns=ns)
         assert result == '|0|1|2|a|b|2|'
@@ -224,9 +221,7 @@ class TestBytesFormatter:
     def test_format_bytes_attr_value_as_string(self):
         """Test formatting with converting bytes attribute values to strings."""
         bf = BytesFormatter()
-        ns = Namespace()
-        ns.a = b'a'
-        ns.b = b'b'
+        ns = Namespace(a=b'a', b=b'b')
         result = bf.format('{0.a}{ns.b}', ns, ns=ns)
         assert result == 'ab'
 
@@ -280,12 +275,10 @@ class TestSubstitutingFormatters:
 
     def test_simple_substitution_items(self, formatfn):
         """Test simple substitution for a indexed field and attribute."""
-        ns = Namespace()
-        ns.a = b'ccddee'
         result = formatfn('{0[1]/a/b/} {a[a]/b+/c/} {ns.a/c/x/}',
                           [b'', b'aabbcc'],
                           a={b'a': b'aabbcc'},
-                          ns=ns)
+                          ns=Namespace(a=b'ccddee'))
         assert result == 'bbbbcc aaccc xxddee'
 
     def test_substitution_with_format_spec(self, formatfn):

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -69,11 +69,65 @@ class TestPartialStringFormatter:
         result = psf.format('|{0}|{1}|{a}|{b}|', None, a=None)
         assert result == '|None||None||'
 
+    def test_missing_args_with_formatspecs(self):
+        """Test missing arguments, replacement fields with format specs."""
+        psf = PartialStringFormatter()
+        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        assert result == '|x |  | 1|  |'
+
+    def test_missing_args_with_conversions(self):
+        """Test missing arguments, replacement fields with conversions."""
+        psf = PartialStringFormatter()
+        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
+        assert result == '|x |  |1 |  |'
+
+    def test_missing_args_with_conversions_none(self):
+        """Test missing arguments, with conversions and None values."""
+        psf = PartialStringFormatter()
+        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', None, a=None)
+        assert result == '|None|  |None|  |'
+
+    def test_missing_args_with_conversions_repr_none(self):
+        """Test missing arguments, with !r conversions and None values."""
+        psf = PartialStringFormatter()
+        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', None, a=None)
+        assert result == '|None|\'\'|None|\'\'|'
+
     def test_alternative_replacement_value(self):
         """Test a case with an alternative replacement value for missing."""
         psf = PartialStringFormatter('*')
         result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x* a 1 b *'
+
+    def test_alt_repl_value_with_formatspecs(self):
+        """Test missing arguments, alternative replacement, format specs."""
+        psf = PartialStringFormatter('*')
+        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        assert result == '|x |* | 1|* |'
+
+    def test_alt_repl_value_with_repr_conversions(self):
+        """Test missing arguments, alt replacement, format specs, !r."""
+        psf = PartialStringFormatter('*')
+        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
+        assert result == '|\'x\'|\'*\'|1 |\'*\'|'
+
+    def test_alt_repl_int_value_with_formatspecs(self):
+        """Test missing arguments, int replacement, format specs."""
+        psf = PartialStringFormatter(0)
+        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        assert result == '|x | 0| 1| 0|'
+
+    def test_alt_repl_int_value_with_conversions(self):
+        """Test missing arguments, int replacement, format specs, conversion."""
+        psf = PartialStringFormatter(0)
+        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
+        assert result == '|x |0 |1 |0 |'
+
+    def test_alt_repl_int_value_with_repr_conversions(self):
+        """Test missing arguments, int replacement, format specs, !r."""
+        psf = PartialStringFormatter(0)
+        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
+        assert result == '|\'x\'|0 |1 |0 |'
 
     def test_keep_replfields_missing_arg(self):
         """Test keeping replacement fields referring to missing arguments."""

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -8,7 +8,7 @@ Pytest tests for libvrt.strformatters.
 
 import pytest
 
-from libvrt.strformatters import PartialStringFormatter, BytesFormatter
+from libvrt.strformatters import PartialFormatter, BytesFormatter
 
 
 class Namespace:
@@ -18,154 +18,154 @@ class Namespace:
     pass
 
 
-class TestPartialStringFormatter:
+class TestPartialFormatter:
 
-    """Tests for PartialStringFormatter"""
+    """Tests for PartialFormatter"""
 
     def test_all_keys_exist(self):
         """Test a case in which all format keys exist."""
-        psf = PartialStringFormatter()
+        pf = PartialFormatter()
         ns = Namespace()
         ns.x = 4
-        result = psf.format('{0}{1} a {a} b {b} c {c[0]} d {d[a]} e {ns.x}',
-                            'x', 'y', a=1, b=2, c=[0], d={'a': 3}, ns=ns)
+        result = pf.format('{0}{1} a {a} b {b} c {c[0]} d {d[a]} e {ns.x}',
+                           'x', 'y', a=1, b=2, c=[0], d={'a': 3}, ns=ns)
         assert result == 'xy a 1 b 2 c 0 d 3 e 4'
 
     def test_missing_arg(self):
         """Test a case with missing positional argument."""
-        psf = PartialStringFormatter()
-        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1, b=2)
+        pf = PartialFormatter()
+        result = pf.format('{0}{1} a {a} b {b}', 'x', a=1, b=2)
         assert result == 'x a 1 b 2'
 
     def test_missing_kwarg(self):
         """Test a case with missing keyword argument."""
-        psf = PartialStringFormatter()
-        result = psf.format('{0}{1} a {a} b {b}', 'x', 'y', a=1)
+        pf = PartialFormatter()
+        result = pf.format('{0}{1} a {a} b {b}', 'x', 'y', a=1)
         assert result == 'xy a 1 b '
 
     def test_missing_list_item(self):
         """Test a case with a missing item in a list."""
-        psf = PartialStringFormatter()
-        result = psf.format('{a[0]} {a[1]}', a=[0])
+        pf = PartialFormatter()
+        result = pf.format('{a[0]} {a[1]}', a=[0])
         assert result == '0 '
 
     def test_missing_dict_key(self):
         """Test a case with a missing key in a dict."""
-        psf = PartialStringFormatter()
-        result = psf.format('{a[a]} {a[b]}', a={'a': 0})
+        pf = PartialFormatter()
+        result = pf.format('{a[a]} {a[b]}', a={'a': 0})
         assert result == '0 '
 
     def test_missing_attr(self):
         """Test a case with a missing attribute."""
-        psf = PartialStringFormatter()
+        pf = PartialFormatter()
         ns = Namespace()
         ns.a = 0
-        result = psf.format('{ns.a} {ns.b}', ns=ns)
+        result = pf.format('{ns.a} {ns.b}', ns=ns)
         assert result == '0 '
 
     def test_missing_args_none(self):
         """Test missing arguments, with None values."""
-        psf = PartialStringFormatter()
-        result = psf.format('|{0}|{1}|{a}|{b}|', None, a=None)
+        pf = PartialFormatter()
+        result = pf.format('|{0}|{1}|{a}|{b}|', None, a=None)
         assert result == '|None||None||'
 
     def test_missing_args_with_formatspecs(self):
         """Test missing arguments, replacement fields with format specs."""
-        psf = PartialStringFormatter()
-        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        pf = PartialFormatter()
+        result = pf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
         assert result == '|x |  | 1|  |'
 
     def test_missing_args_with_conversions(self):
         """Test missing arguments, replacement fields with conversions."""
-        psf = PartialStringFormatter()
-        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
+        pf = PartialFormatter()
+        result = pf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
         assert result == '|x |  |1 |  |'
 
     def test_missing_args_with_conversions_none(self):
         """Test missing arguments, with conversions and None values."""
-        psf = PartialStringFormatter()
-        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', None, a=None)
+        pf = PartialFormatter()
+        result = pf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', None, a=None)
         assert result == '|None|  |None|  |'
 
     def test_missing_args_with_conversions_repr_none(self):
         """Test missing arguments, with !r conversions and None values."""
-        psf = PartialStringFormatter()
-        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', None, a=None)
+        pf = PartialFormatter()
+        result = pf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', None, a=None)
         assert result == '|None|\'\'|None|\'\'|'
 
     def test_alternative_replacement_value(self):
         """Test a case with an alternative replacement value for missing."""
-        psf = PartialStringFormatter('*')
-        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
+        pf = PartialFormatter('*')
+        result = pf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x* a 1 b *'
 
     def test_alt_repl_value_with_formatspecs(self):
         """Test missing arguments, alternative replacement, format specs."""
-        psf = PartialStringFormatter('*')
-        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        pf = PartialFormatter('*')
+        result = pf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
         assert result == '|x |* | 1|* |'
 
     def test_alt_repl_value_with_repr_conversions(self):
         """Test missing arguments, alt replacement, format specs, !r."""
-        psf = PartialStringFormatter('*')
-        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
+        pf = PartialFormatter('*')
+        result = pf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
         assert result == '|\'x\'|\'*\'|1 |\'*\'|'
 
     def test_alt_repl_int_value_with_formatspecs(self):
         """Test missing arguments, int replacement, format specs."""
-        psf = PartialStringFormatter(0)
-        result = psf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
+        pf = PartialFormatter(0)
+        result = pf.format('|{0:2}|{1:2}|{a:2}|{b:2}|', 'x', a=1)
         assert result == '|x | 0| 1| 0|'
 
     def test_alt_repl_int_value_with_conversions(self):
         """Test missing arguments, int replacement, format specs, conversion."""
-        psf = PartialStringFormatter(0)
-        result = psf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
+        pf = PartialFormatter(0)
+        result = pf.format('|{0!s:2}|{1!s:2}|{a!s:2}|{b!s:2}|', 'x', a=1)
         assert result == '|x |0 |1 |0 |'
 
     def test_alt_repl_int_value_with_repr_conversions(self):
         """Test missing arguments, int replacement, format specs, !r."""
-        psf = PartialStringFormatter(0)
-        result = psf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
+        pf = PartialFormatter(0)
+        result = pf.format('|{0!r:2}|{1!r:2}|{a!r:2}|{b!r:2}|', 'x', a=1)
         assert result == '|\'x\'|0 |1 |0 |'
 
     def test_keep_replfields_missing_arg(self):
         """Test keeping replacement fields referring to missing arguments."""
-        psf = PartialStringFormatter(None)
-        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
+        pf = PartialFormatter(None)
+        result = pf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x{1} a 1 b {b}'
 
     def test_keep_replfields_missing_args_all(self):
         """Test keeping all replacement fields (no arguments)."""
-        psf = PartialStringFormatter(None)
+        pf = PartialFormatter(None)
         fmt = '{0}{1} a {a} b {b}'
-        result = psf.format(fmt)
+        result = pf.format(fmt)
         assert result == fmt
 
     def test_keep_replfields_missing_args_double_curlies(self):
         """Test keeping replacement fields, format with double curly brackets."""
-        psf = PartialStringFormatter(None)
-        result = psf.format('{0}{1} {{0}} a {a} b {b} {{a}}', 'x', a=1)
+        pf = PartialFormatter(None)
+        result = pf.format('{0}{1} {{0}} a {a} b {b} {{a}}', 'x', a=1)
         assert result == 'x{1} {0} a 1 b {b} {a}'
 
     def test_keep_replfields_missing_list_item(self):
         """Test keeping a replacement field with a missing item in a list."""
-        psf = PartialStringFormatter(None)
-        result = psf.format('{a[0]} {a[1]}', a=[0])
+        pf = PartialFormatter(None)
+        result = pf.format('{a[0]} {a[1]}', a=[0])
         assert result == '0 '
 
     def test_keep_replfields_missing_dict_key(self):
         """Test keeping a replacement field with a missing key in a dict."""
-        psf = PartialStringFormatter(None)
-        result = psf.format('{a[a]} {a[b]}', a={'a': 0})
+        pf = PartialFormatter(None)
+        result = pf.format('{a[a]} {a[b]}', a={'a': 0})
         assert result == '0 '
 
     def test_keep_replfields_missing_attr(self):
         """Test keeping a replacement field with a missing attribute."""
-        psf = PartialStringFormatter(None)
+        pf = PartialFormatter(None)
         ns = Namespace()
         ns.a = 0
-        result = psf.format('{ns.a} {ns.b}', ns=ns)
+        result = pf.format('{ns.a} {ns.b}', ns=ns)
         assert result == '0 '
 
 

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -63,6 +63,12 @@ class TestPartialStringFormatter:
         result = psf.format('{ns.a} {ns.b}', ns=ns)
         assert result == '0 '
 
+    def test_missing_args_none(self):
+        """Test missing arguments, with None values."""
+        psf = PartialStringFormatter()
+        result = psf.format('|{0}|{1}|{a}|{b}|', None, a=None)
+        assert result == '|None||None||'
+
     def test_alternative_replacement_value(self):
         """Test a case with an alternative replacement value for missing."""
         psf = PartialStringFormatter('*')

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -8,7 +8,7 @@ Pytest tests for libvrt.strformatters.
 
 import pytest
 
-from libvrt.strformatters import PartialStringFormatter
+from libvrt.strformatters import PartialStringFormatter, BytesFormatter
 
 
 class Namespace:
@@ -167,3 +167,50 @@ class TestPartialStringFormatter:
         ns.a = 0
         result = psf.format('{ns.a} {ns.b}', ns=ns)
         assert result == '0 '
+
+
+class TestBytesFormatter:
+
+    """Tests for BytesFormatter"""
+
+    def test_format_strings(self):
+        """Test formatting strings with BytesFormatter."""
+        bf = BytesFormatter()
+        ns = Namespace()
+        ns.a = '2'
+        result = bf.format('|{0}|{1[0]}|{2.a}|{a}|{b[a]}|{ns.a}|',
+                           0, [1, 2], ns, a='a', b={'a': 'b'}, ns=ns)
+        assert result == '|0|1|2|a|b|2|'
+
+    def test_format_bytes_as_string(self):
+        """Test formatting with converting bytes values to strings."""
+        bf = BytesFormatter()
+        result = bf.format('{0}{a}', b'0', a=b'a')
+        assert result == '0a'
+
+    def test_format_bytes_list_item_as_string(self):
+        """Test formatting with converting bytes list item values to strings."""
+        bf = BytesFormatter()
+        result = bf.format('{0[0]}{a[1]}', [b'0', b'1'], a=[b'a', b'b'])
+        assert result == '0b'
+
+    def test_format_bytes_dict_value_as_string(self):
+        """Test formatting with converting bytes dict values to strings."""
+        bf = BytesFormatter()
+        result = bf.format('{0[a]}{a[b]}', {'a': b'0'}, a={'b': b'b'})
+        assert result == '0b'
+
+    def test_format_bytes_attr_value_as_string(self):
+        """Test formatting with converting bytes attribute values to strings."""
+        bf = BytesFormatter()
+        ns = Namespace()
+        ns.a = b'a'
+        ns.b = b'b'
+        result = bf.format('{0.a}{ns.b}', ns, ns=ns)
+        assert result == 'ab'
+
+    def test_format_bytes_dict_key_as_string(self):
+        """Test formatting with converting bytes dict keys to strings."""
+        bf = BytesFormatter()
+        result = bf.format('{0[a]}{a[b]}', {b'a': b'0'}, a={b'b': b'b'})
+        assert result == '0b'

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -69,39 +69,39 @@ class TestPartialStringFormatter:
         result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x* a 1 b *'
 
-    def test_keep_formatspecs_missing_arg(self):
-        """Test keeping formatspecs referring to missing arguments."""
+    def test_keep_replfields_missing_arg(self):
+        """Test keeping replacement fields referring to missing arguments."""
         psf = PartialStringFormatter(None)
         result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x{1} a 1 b {b}'
 
-    def test_keep_formatspecs_missing_args_all(self):
-        """Test keeping all formatspecs (no arguments)."""
+    def test_keep_replfields_missing_args_all(self):
+        """Test keeping all replacement fields (no arguments)."""
         psf = PartialStringFormatter(None)
         fmt = '{0}{1} a {a} b {b}'
         result = psf.format(fmt)
         assert result == fmt
 
-    def test_keep_formatspecs_missing_args_double_curlies(self):
-        """Test keeping formatspecs, format with double curly brackets."""
+    def test_keep_replfields_missing_args_double_curlies(self):
+        """Test keeping replacement fields, format with double curly brackets."""
         psf = PartialStringFormatter(None)
         result = psf.format('{0}{1} {{0}} a {a} b {b} {{a}}', 'x', a=1)
         assert result == 'x{1} {0} a 1 b {b} {a}'
 
-    def test_keep_formatspecs_missing_list_item(self):
-        """Test keeping a formatspec with a missing item in a list."""
+    def test_keep_replfields_missing_list_item(self):
+        """Test keeping a replacement field with a missing item in a list."""
         psf = PartialStringFormatter(None)
         result = psf.format('{a[0]} {a[1]}', a=[0])
         assert result == '0 '
 
-    def test_keep_formatspecs_missing_dict_key(self):
-        """Test keeping a formatspec with a missing key in a dict."""
+    def test_keep_replfields_missing_dict_key(self):
+        """Test keeping a replacement field with a missing key in a dict."""
         psf = PartialStringFormatter(None)
         result = psf.format('{a[a]} {a[b]}', a={'a': 0})
         assert result == '0 '
 
-    def test_keep_formatspecs_missing_attr(self):
-        """Test keeping a formatspec with a missing attribute."""
+    def test_keep_replfields_missing_attr(self):
+        """Test keeping a replacement field with a missing attribute."""
         psf = PartialStringFormatter(None)
         ns = Namespace()
         ns.a = 0

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -68,3 +68,42 @@ class TestPartialStringFormatter:
         psf = PartialStringFormatter('*')
         result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
         assert result == 'x* a 1 b *'
+
+    def test_keep_formatspecs_missing_arg(self):
+        """Test keeping formatspecs referring to missing arguments."""
+        psf = PartialStringFormatter(None)
+        result = psf.format('{0}{1} a {a} b {b}', 'x', a=1)
+        assert result == 'x{1} a 1 b {b}'
+
+    def test_keep_formatspecs_missing_args_all(self):
+        """Test keeping all formatspecs (no arguments)."""
+        psf = PartialStringFormatter(None)
+        fmt = '{0}{1} a {a} b {b}'
+        result = psf.format(fmt)
+        assert result == fmt
+
+    def test_keep_formatspecs_missing_args_double_curlies(self):
+        """Test keeping formatspecs, format with double curly brackets."""
+        psf = PartialStringFormatter(None)
+        result = psf.format('{0}{1} {{0}} a {a} b {b} {{a}}', 'x', a=1)
+        assert result == 'x{1} {0} a 1 b {b} {a}'
+
+    def test_keep_formatspecs_missing_list_item(self):
+        """Test keeping a formatspec with a missing item in a list."""
+        psf = PartialStringFormatter(None)
+        result = psf.format('{a[0]} {a[1]}', a=[0])
+        assert result == '0 '
+
+    def test_keep_formatspecs_missing_dict_key(self):
+        """Test keeping a formatspec with a missing key in a dict."""
+        psf = PartialStringFormatter(None)
+        result = psf.format('{a[a]} {a[b]}', a={'a': 0})
+        assert result == '0 '
+
+    def test_keep_formatspecs_missing_attr(self):
+        """Test keeping a formatspec with a missing attribute."""
+        psf = PartialStringFormatter(None)
+        ns = Namespace()
+        ns.a = 0
+        result = psf.format('{ns.a} {ns.b}', ns=ns)
+        assert result == '0 '

--- a/vrt-tools/tests/libvrt/test_strformatters.py
+++ b/vrt-tools/tests/libvrt/test_strformatters.py
@@ -8,7 +8,12 @@ Pytest tests for libvrt.strformatters.
 
 import pytest
 
-from libvrt.strformatters import PartialFormatter, BytesFormatter
+from libvrt.strformatters import (
+    PartialFormatter,
+    BytesFormatter,
+    SubstitutingFormatter,
+    SubstitutingBytesFormatter
+)
 
 
 class Namespace:
@@ -214,3 +219,135 @@ class TestBytesFormatter:
         bf = BytesFormatter()
         result = bf.format('{0[a]}{a[b]}', {b'a': b'0'}, a={b'b': b'b'})
         assert result == '0b'
+
+
+class TestSubstitutingFormatter:
+
+    """Tests for SubstitutingFormatter"""
+
+    @pytest.fixture(autouse=True)
+    def set_formatter(self):
+        """Set self.sf to a SubstitutingFormatter instance."""
+        self.sf = SubstitutingFormatter()
+
+    def test_simple_substitution(self):
+        """Test simple substitution for a simple field."""
+        result = self.sf.format('{0/a/b/} {a/b+/c/}', 'aabbcc', a='aabbcc')
+        assert result == 'bbbbcc aaccc'
+
+    def test_simple_substitution_items(self):
+        """Test simple substitution for a indexed field and attribute."""
+        ns = Namespace()
+        ns.a = 'ccddee'
+        result = self.sf.format('{0[1]/a/b/} {a[a]/b+/c/} {ns.a/c/x/}',
+                                ['', 'aabbcc'],
+                                a={'a': 'aabbcc'},
+                                ns=ns)
+        assert result == 'bbbbcc aaccc xxddee'
+
+    def test_substitution_with_format_spec(self):
+        """Test substitution with a format specification."""
+        result = self.sf.format('|{0/a/b/:8s}|{a/b+/c/:@^10s}|',
+                                'aabbcc', a='aabbcc')
+        assert result == '|bbbbcc  |@@aaccc@@@|'
+
+    def test_substitution_with_conversion(self):
+        """Test substitution with conversion."""
+        result = self.sf.format('{0/a/b/!r} {a/b+/c/!s}',
+                                'aabbcc', a='aabbcc')
+        assert result == '\'bbbbcc\' aaccc'
+
+    def test_multiple_substitutions(self):
+        """Test multiple substitutions with different separators."""
+        result = self.sf.format('{0 /a/b/, /b+/cc/ ; /c/dd/ /e/f//f/g/}',
+                                'aabbccddeeff')
+        assert result == 'ddddddddddgggg'
+
+    def test_substitution_groups(self):
+        """Test substitution with groups."""
+        result = self.sf.format(
+            r'{0/^([a-z])(.+?)(?P<x>[0-9]+)(.+)([a-z])$/\g<5>\g<4>\g<x>\3\2\1/}',
+            'abc123def')
+        assert result == 'fde123123bca'
+
+    def test_protect_slashes(self):
+        """Test substitutions with backslash-protected slashes."""
+        result = self.sf.format(r'{0/\//\/\//} {1/(.)\/(.)/\2x\1}',
+                                'a//b', 'b/a')
+        assert result == r'a////b axb'
+
+    def test_handle_double_backslashes(self):
+        """Test substitutions with double backslashes."""
+        # Important to test in particular at the end of a pattern or
+        # substitution
+        result = self.sf.format(r'{0/a\\b/b\\a/} {1/\\/\\\\/}',
+                                r'aa\bb', r'b\a')
+        assert result == r'ab\ab b\\a'
+
+
+class TestSubstitutingBytesFormatter:
+
+    """Tests for SubstitutingBytesFormatter"""
+
+    # This class effectively duplicates TestSubstitutingFormatter with
+    # SubstitutingBytesFormatter and bytes values for format arguments.
+    # How could they be combined?
+
+    @pytest.fixture(autouse=True)
+    def set_formatter(self):
+        """Set self.sf to a SubstitutingBytesFormatter instance."""
+        self.sf = SubstitutingBytesFormatter()
+
+    def test_simple_substitution(self):
+        """Test simple substitution for a simple field."""
+        result = self.sf.format('{0/a/b/} {a/b+/c/}', b'aabbcc', a=b'aabbcc')
+        assert result == 'bbbbcc aaccc'
+
+    def test_simple_substitution_items(self):
+        """Test simple substitution for a indexed field and attribute."""
+        ns = Namespace()
+        ns.a = b'ccddee'
+        result = self.sf.format('{0[1]/a/b/} {a[a]/b+/c/} {ns.a/c/x/}',
+                                [b'', b'aabbcc'],
+                                a={b'a': b'aabbcc'},
+                                ns=ns)
+        assert result == 'bbbbcc aaccc xxddee'
+
+    def test_substitution_with_format_spec(self):
+        """Test substitution with a format specification."""
+        result = self.sf.format('|{0/a/b/:8s}|{a/b+/c/:@^10s}|',
+                                b'aabbcc', a=b'aabbcc')
+        assert result == '|bbbbcc  |@@aaccc@@@|'
+
+    def test_substitution_with_conversion(self):
+        """Test substitution with conversion."""
+        result = self.sf.format('{0/a/b/!r} {a/b+/c/!s}',
+                                b'aabbcc', a=b'aabbcc')
+        assert result == '\'bbbbcc\' aaccc'
+
+    def test_multiple_substitutions(self):
+        """Test multiple substitutions with different separators."""
+        result = self.sf.format('{0 /a/b/, /b+/cc/ ; /c/dd/ /e/f//f/g/}',
+                                b'aabbccddeeff')
+        assert result == 'ddddddddddgggg'
+
+    def test_substitution_groups(self):
+        """Test substitution with groups."""
+        result = self.sf.format(
+            r'{0/^([a-z])(.+?)(?P<x>[0-9]+)(.+)([a-z])$/\g<5>\g<4>\g<x>\3\2\1/}',
+            b'abc123def')
+        assert result == 'fde123123bca'
+
+    def test_protect_slashes(self):
+        """Test substitutions with backslash-protected slashes."""
+        result = self.sf.format(r'{0/\//\/\//} {1/(.)\/(.)/\2x\1}',
+                                b'a//b', b'b/a')
+        assert result == r'a////b axb'
+
+    def test_handle_double_backslashes(self):
+        """Test substitutions with double backslashes."""
+        # Important to test in particular at the end of a pattern or
+        # substitution
+        result = self.sf.format(r'{0/a\\b/b\\a/} {1/\\/\\\\/}',
+                                br'aa\bb', br'b\a')
+        assert result == r'ab\ab b\\a'

--- a/vrt-tools/tests/scripttestlib.py
+++ b/vrt-tools/tests/scripttestlib.py
@@ -12,6 +12,11 @@ information.
 """
 
 
+# TODO:
+# - Support overriding "status" (xfail, skip, skipif) in a grouped
+#   transformation and in an individual test specified as a dict.
+
+
 import glob
 import importlib
 import os
@@ -181,6 +186,8 @@ def expand_testcases(fname_testcases_dictlist, granularity=None):
         # print('add_transforms', base, add)
         if isinstance(add, dict):
             add = [{key: val} for key, val in add.items()]
+        elif add is None or isinstance(add, (str, int)):
+            add = [add]
         base.extend(add)
         return base
 
@@ -228,14 +235,21 @@ def expand_testcases(fname_testcases_dictlist, granularity=None):
                 # Expand grouped transformations
                 input_output = expand_grouped_transforms(
                     input_output, tc['transform'])
-                name_format = name_format.replace('}:', '}:{transformnum:d}:')
+                name_format = name_format.replace('}:', '}:{transnum:d}:')
             # print('name_format', name_format)
-            for trnum, (real_input, real_output) in enumerate(input_output):
-                subcase_name = (tcname + (' (' + inputname + ')'
-                                          if inputname else ''))
+            for trnum, input_output_item in enumerate(input_output):
+                real_input, real_output = input_output_item[0:2]
+                transname = (
+                    ': ' + input_output_item[2] if len(input_output_item) > 2
+                    else '')
+                subcase_name = (
+                    tcname
+                    + (f' ({inputname})' if inputname else '')
+                    + (f' (transform {trnum + 1}{transname})'
+                       if 'transform' in tc else ''))
                 full_name = name_format.format(
                     fname=fname, num=tcnum + 1, inputnum=inputnum + 1,
-                    transformnum=trnum + 1, name=subcase_name)
+                    transnum=trnum + 1, name=subcase_name)
                 subcases.extend(make_output_subcases(
                     full_name, real_input, real_output))
         return subcases
@@ -458,17 +472,22 @@ def expand_testcases(fname_testcases_dictlist, granularity=None):
         """Return copy of [`input_`, `output`] with `transform_group` added.
 
         Add to a deep copy of `input_` and `output` the applicable
-        transformations in `transform_group` and return them as a pair
-        list. `input_` and `output` correspond to the dicts ``input``
-        and ``output`` in a scripttestlib test.
+        transformations in `transform_group` and return them as list
+        of pairs or triples (lists). (The optional third item is the
+        value of the ``name`` of the transformation group.)`input_`
+        and `output` correspond to the dicts ``input`` and ``output``
+        in a scripttestlib test.
         """
         result = [deepcopy(input_), deepcopy(output)]
         # Input and output top targets
         target_tops = {'input': result[0], 'output': result[1]}
         # print('add_transform_group', result, transform_group)
         # transform_group is a dict that may contain keys "input",
-        # "output-expected", "output-actual"
+        # "output-expected", "output-actual", "name"
         for transform_top_name, transform_top in transform_group.items():
+            if transform_top_name == 'name':
+                result.append(transform_top)
+                continue
             # target_top is "input" or "output"
             target_top, sep, kind = transform_top_name.partition('-')
             # The key for these transformations in input_ or output:
@@ -541,7 +560,7 @@ def expand_testcases(fname_testcases_dictlist, granularity=None):
             raise ValueError(
                 'Grouped transformations currently work only with string'
                 ' values and dicts with key "value": ' + repr(target))
-        if isinstance(transform_items, dict):
+        if not isinstance(transform_items, list):
             transform_items = [transform_items]
         for transform_item in transform_items:
             target[transform_key].append(transform_item)
@@ -905,11 +924,18 @@ def _transform_value(value, trans):
         return value
     # Convert a dict to a list of single-item dicts
     if isinstance(trans, dict):
-        trans = (dict([(key, val)]) for key, val in trans.items())
+        trans = [dict([(key, val)]) for key, val in trans.items()]
+    # str or int is converted to a list containing the value
+    elif isinstance(trans, (str, int)):
+        trans = [trans]
     # If value is a list, transform each item separately
     if isinstance(value, list):
         return [_transform_value(item, trans) for item in value]
     for transitem in trans:
+        # If the transformation item is not a dict, treat the value as
+        # the complete new value
+        if not isinstance(transitem, dict):
+            transitem = {'set-value': transitem}
         for transname, transval in transitem.items():
             # print(transname, transval)
             try:

--- a/vrt-tools/tests/scripttestlib.py
+++ b/vrt-tools/tests/scripttestlib.py
@@ -1352,8 +1352,9 @@ def _transform_value_shell(value, code, **kwargs):
 
 def _exec_python_func(code, value):
     """Execute Python code `code` (function body) with arg `value`."""
-    funcdef = ('def func(value):\n '
+    funcdef = ('def func(value):\n'
                + re.sub(r'^', '    ', code, flags=re.MULTILINE))
+    # print(funcdef)
     exec(funcdef, globals())
     return func(value)
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -12,12 +12,13 @@
 
 
 # Tests for the functionality of the original script by Jussi
-# Piitulainen (but with --type=random as the default)
+# Piitulainen (but with --type=random and text, paragraph, sentence as
+# the defaults)
 
 
-- name: 'vrt-add-id: Default options + --type=counter'
+- name: 'vrt-add-id: Default options + --type=counter --element=sentence'
   input:
-    cmdline: vrt-add-id --type=counter
+    cmdline: vrt-add-id --type=counter --element=sentence
     stdin: &input-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
@@ -85,30 +86,6 @@
         vrt-add-id: added 3 sentence ids
 
 
-- name: 'vrt-add-id: Default options'
-  input:
-    cmdline: vrt-add-id
-    stdin: *input-1
-  output:
-    stdout:
-      regex: |
-        <!-- #vrt positional-attributes: word -->
-        <text n="1">
-        <sentence a="a" id="[0-9a-f]{8}">
-        a
-        </sentence>
-        <sentence a="b" id="[0-9a-f]{8}">
-        b
-        </sentence>
-        </text>
-        <text n="2">
-        <sentence a="c" id="[0-9a-f]{8}">
-        c
-        </sentence>
-        </text>
-  transform: *transform-fast-s3
-
-
 - name: 'vrt-add-id: --element=text'
   input:
     cmdline: vrt-add-id --type=counter --element="text"
@@ -173,7 +150,7 @@
 
 - name: 'vrt-add-id: --id'
   input:
-    cmdline: vrt-add-id --type=counter --id="sid"
+    cmdline: vrt-add-id --type=counter --id="sid" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -196,7 +173,7 @@
 
 - name: 'vrt-add-id: --start=0'
   input:
-    cmdline: vrt-add-id --type=counter --start=0
+    cmdline: vrt-add-id --type=counter --start=0 --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -219,7 +196,7 @@
 
 - name: 'vrt-add-id: --prefix'
   input:
-    cmdline: vrt-add-id --type=counter --prefix=s-
+    cmdline: vrt-add-id --type=counter --prefix=s- --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -278,7 +255,7 @@
 
 - name: 'vrt-add-id: Existing id attribute (without --force)'
   input:
-    cmdline: vrt-add-id --type=counter --id=a
+    cmdline: vrt-add-id --type=counter --id=a --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -304,7 +281,7 @@
 
 - name: 'vrt-add-id: Overwrite existing id attribute with --force'
   input:
-    cmdline: vrt-add-id --type=counter --id=a --force
+    cmdline: vrt-add-id --type=counter --id=a --force --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -447,7 +424,7 @@
 
 - name: 'vrt-add-id: --type=random (implicit random seed)'
   input:
-    cmdline: vrt-add-id --type=random
+    cmdline: vrt-add-id --type=random --element=sentence
     stdin: *input-1
   output:
     stdout: &output-random
@@ -471,7 +448,7 @@
 
 - name: 'vrt-add-id: --type=random --seed="" (explicit random seed)'
   input:
-    cmdline: vrt-add-id --type=random --seed=""
+    cmdline: vrt-add-id --type=random --seed="" --element=sentence
     stdin: *input-1
   output:
     stdout: *output-random
@@ -480,7 +457,7 @@
 
 - name: 'vrt-add-id: --type=random --seed=1'
   input:
-    cmdline: vrt-add-id --type=random --seed=1
+    cmdline: vrt-add-id --type=random --seed=1 --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -505,7 +482,7 @@
 
 - name: 'vrt-add-id: --type=random --max=3'
   input:
-    cmdline: vrt-add-id --type=random --max=3 --seed=2
+    cmdline: vrt-add-id --type=random --max=3 --seed=2 --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -527,7 +504,7 @@
 
 - name: 'vrt-add-id: --type=random --max=20 (decimal, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --max=20 --seed=1
+    cmdline: vrt-add-id --type=random --max=20 --seed=1 --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -549,7 +526,7 @@
 
 - name: 'vrt-add-id: --type=random --max=0x1000 (hex, values of 3 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --max=0x1000 --seed=1
+    cmdline: vrt-add-id --type=random --max=0x1000 --seed=1 --element=sentence
     stdin: *input-1
   output:
     stdout: &stdout-random-4096-seed-1 |
@@ -571,7 +548,7 @@
 
 - name: 'vrt-add-id: --type=random --max=2^8 (power, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --max=2^8 --seed=1
+    cmdline: vrt-add-id --type=random --max=2^8 --seed=1 --element=sentence
     stdin: *input-1
   output:
     stdout: &stdout-random-256-seed-1 |
@@ -593,7 +570,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:03x)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03x}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03x}' --element=sentence
     stdin: *input-1
   output:
     stdout: *stdout-random-4096-seed-1
@@ -601,7 +578,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:03X)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03X}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03X}' --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -615,7 +592,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:#05x)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:#05x}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:#05x}' --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -626,7 +603,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:04o)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:04o}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:04o}' --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -640,7 +617,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:012b)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:012b}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:012b}' --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -654,7 +631,7 @@
 
 - name: 'vrt-add-id: --type=random --max from format (:/>12b)'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --format='{id:/>12b}'
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:/>12b}' --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -669,8 +646,8 @@
 - name: 'vrt-add-id: --type=random --max from format (:04d)'
   input:
     cmdline:
-    - vrt-add-id --type=random --seed=1 --format='{id:04d}'
-    - vrt-add-id --type=random --seed=1 --format='{id:04}'
+    - vrt-add-id --type=random --seed=1 --format='{id:04d}' --element=sentence
+    - vrt-add-id --type=random --seed=1 --format='{id:04}' --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -692,7 +669,7 @@
 
 - name: 'vrt-add-id: --type=random --max=2 (too small value)'
   input:
-    cmdline: vrt-add-id --type=random --max=2 --seed=2
+    cmdline: vrt-add-id --type=random --max=2 --seed=2 --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -790,7 +767,7 @@
 
 - name: 'vrt-add-id: --type=random, seed from file'
   input:
-    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt" --element=sentence
     stdin: *input-1
     file:seed.txt: '1'
   output:
@@ -814,7 +791,7 @@
 
 - name: 'vrt-add-id: --type=random, seed from 1 MiB file'
   input:
-    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt" --element=sentence
     stdin: *input-1
     file:seed.txt:
       value: ''
@@ -860,7 +837,7 @@
 
 - name: 'vrt-add-id: --type=random, non-existent seed file'
   input:
-    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt" --element=sentence
     stdin: *input-1
   output:
     stdout: ''
@@ -873,7 +850,7 @@
 
 - name: 'vrt-add-id: --type=counter --format'
   input:
-    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -895,7 +872,7 @@
 
 - name: 'vrt-add-id: --type=counter --format without width'
   input:
-    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:x}*"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:x}*" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -917,7 +894,7 @@
 
 - name: 'vrt-add-id: --type=counter --format with width, default type'
   input:
-    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03}*"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03}*" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -939,7 +916,7 @@
 
 - name: 'vrt-add-id: --type=counter --format --prefix'
   input:
-    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*" --prefix="x-"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*" --prefix="x-" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -961,7 +938,7 @@
 
 - name: 'vrt-add-id: --type=random --format'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*"
+    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -983,7 +960,7 @@
 
 - name: 'vrt-add-id: --type=random --format --prefix'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*" --prefix="x-"
+    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*" --prefix="x-" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1005,7 +982,7 @@
 
 - name: 'vrt-add-id: --type=random --format; double {id}'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --max=100 --format="*{id:03d}-{id:02x}*"
+    cmdline: vrt-add-id --type=random --seed=1 --max=100 --format="*{id:03d}-{id:02x}*" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1036,7 +1013,7 @@
 
 - name: 'vrt-add-id: {id} with different format specs'
   input:
-    cmdline: vrt-add-id --type=counter --format="{id:<1d}" --verbose
+    cmdline: vrt-add-id --type=counter --format="{id:<1d}" --verbose --element=sentence
     stdin: *input-1
   output:
     stdout: *output-1-s3
@@ -1095,7 +1072,7 @@
 
 - name: 'vrt-add-id: Format containing fixed characters to be XML-encoded'
   input:
-    cmdline: vrt-add-id --type=counter --format="<{id}" --verbose
+    cmdline: vrt-add-id --type=counter --format="<{id}" --verbose --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1133,7 +1110,7 @@
 
 - name: 'vrt-add-id: Format spec producing characters to be XML-encoded'
   input:
-    cmdline: vrt-add-id --type=counter --format="{id:<>2d}" --verbose
+    cmdline: vrt-add-id --type=counter --format="{id:<>2d}" --verbose --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1177,7 +1154,7 @@
 
 - name: 'vrt-add-id: Format with literal { and }'
   input:
-    cmdline: vrt-add-id --type=counter --format="{{-{id}-}}"
+    cmdline: vrt-add-id --type=counter --format="{{-{id}-}}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1188,7 +1165,7 @@
 
 - name: 'vrt-add-id: Format with literal "{id}"'
   input:
-    cmdline: vrt-add-id --type=counter --format="{{id}}-{id}"
+    cmdline: vrt-add-id --type=counter --format="{{id}}-{id}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1199,7 +1176,7 @@
 
 - name: 'vrt-add-id: Format with literal "{idnum[...]}"'
   input:
-    cmdline: vrt-add-id --type=counter --format="{{idnum[sentence]}}-{{{{idnum[x]}}}}-{id}"
+    cmdline: vrt-add-id --type=counter --format="{{idnum[sentence]}}-{{{{idnum[x]}}}}-{id}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1210,7 +1187,7 @@
 
 - name: 'vrt-add-id: Format with literal { and } immediately around replacement field'
   input:
-    cmdline: vrt-add-id --type=counter --format="{{{id}}}"
+    cmdline: vrt-add-id --type=counter --format="{{{id}}}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1221,7 +1198,7 @@
 
 - name: 'vrt-add-id: Format with literal {{ and }} immediately around replacement field'
   input:
-    cmdline: vrt-add-id --type=counter --format="{{{{{id}}}}}"
+    cmdline: vrt-add-id --type=counter --format="{{{{{id}}}}}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1235,7 +1212,7 @@
 
 - name: 'vrt-add-id: --hash; format with {hash}'
   input:
-    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: &output-hash |
@@ -1257,7 +1234,7 @@
 
 - name: 'vrt-add-id: --hash; format with {hash1}'
   input:
-    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: *output-hash
@@ -1265,7 +1242,7 @@
 
 - name: 'vrt-add-id: Multiple --hash'
   input:
-    cmdline: vrt-add-id --type=counter --hash=abc --hash=def --hash=ghi --format="{hash1:.4}-{hash2:.4}-{hash3:.6}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --hash=def --hash=ghi --format="{hash1:.4}-{hash2:.4}-{hash3:.6}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1288,8 +1265,8 @@
 - name: 'vrt-add-id: Random --hash (empty string)'
   input:
     cmdline: |
-      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out1.vrt;
-      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out2.vrt
+      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out1.vrt --element=sentence;
+      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out2.vrt --element=sentence
     shell: True
     file:in.vrt: *input-1
   output:
@@ -1335,7 +1312,7 @@
 
 - name: 'vrt-add-id: Two random hashes are different'
   input:
-    cmdline: vrt-add-id --type=counter --hash="" --hash="" --format="{hash1}-{hash2}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash="" --hash="" --format="{hash1}-{hash2}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout:
@@ -1351,7 +1328,7 @@
 
 - name: 'vrt-add-id: Format refers to {hash} with no --hash options'
   input:
-    cmdline: vrt-add-id --type=counter --format="{hash:.4}"
+    cmdline: vrt-add-id --type=counter --format="{hash:.4}" --element=sentence
     stdin: *input-1
   output:
     stdout: ''
@@ -1364,7 +1341,7 @@
 
 - name: 'vrt-add-id: Format refers to non-existent {hashN}'
   input:
-    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: ''
@@ -1378,7 +1355,7 @@
 
 - name: 'vrt-add-id: --format with {elem[attr]}'
   input:
-    cmdline: vrt-add-id --type=counter --format="{sentence[a]}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --format="{sentence[a]}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1409,7 +1386,7 @@
 
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
   input:
-    cmdline: vrt-add-id --type=counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}" --element=sentence
     stdin: &input-para |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
@@ -1469,7 +1446,7 @@
 
 - name: 'vrt-add-id: --format with {this[attr]}'
   input:
-    cmdline: vrt-add-id --type=counter --format="{this[a]}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --format="{this[a]}-{id:03d}" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1599,7 +1576,7 @@
 
 - name: 'vrt-add-id: --format with idnum[elem] where no ids added to elem'
   input:
-    cmdline: vrt-add-id --format="{idnum[text]}"
+    cmdline: vrt-add-id --format="{idnum[text]}" --element=sentence
     stdin: *input-1
   output:
     stdout: ''
@@ -1720,7 +1697,7 @@
 
 - name: 'vrt-add-id: --format referring to non-existent element or attribute'
   input:
-    cmdline: vrt-add-id --format="{id}-{paragraph[z]}"
+    cmdline: vrt-add-id --format="{id}-{paragraph[z]}" --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -1991,7 +1968,7 @@
 
 - name: 'vrt-add-id: --rename, no existing attribute'
   input:
-    cmdline: vrt-add-id --type=counter --id=x --rename
+    cmdline: vrt-add-id --type=counter --id=x --rename --element=sentence
     stdin: &input-multiattr |
       <!-- #vrt positional-attributes: word -->
       <text a="a" n="1" n_1="a" n_2="b">
@@ -2036,7 +2013,7 @@
 
 - name: 'vrt-add-id: --rename, existing attribute'
   input:
-    cmdline: vrt-add-id --type=counter --id=a --rename
+    cmdline: vrt-add-id --type=counter --id=a --rename --element=sentence
     stdin: *input-multiattr
   output:
     stdout: |
@@ -2421,7 +2398,7 @@
 
 - name: 'vrt-add-id: --verbose; {id} with different format specifications (faster method)'
   input:
-    cmdline: vrt-add-id --type=counter --format="{id:d}" --verbose
+    cmdline: vrt-add-id --type=counter --format="{id:d}" --verbose --element=sentence
     stdin: *input-1
   output:
     stdout: *output-1-s3
@@ -2489,3 +2466,239 @@
     stderr: |
       vrt-add-id: using the slower method because of not finding elements paragraph, x
       vrt-add-id: added 3 sentence ids, 0 paragraph ids, 0 x ids
+
+
+# Defaulting to text, paragraph, sentence
+
+- name: 'vrt-add-id: Default elements and other default options'
+  input:
+    cmdline: vrt-add-id
+    stdin: *input-para
+  output:
+    stdout:
+      regex: &output-para-default-regex |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1" id="t-[0-9a-f]{8}-[0-9a-f]{8}">
+        <paragraph p="p1" id="p-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        <sentence a="a" id="s-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        a
+        </sentence>
+        </paragraph>
+        <paragraph p="p2" id="p-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        <sentence a="b" id="s-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        b
+        </sentence>
+        </paragraph>
+        </text>
+        <text n="2" id="t-[0-9a-f]{8}-[0-9a-f]{8}">
+        <paragraph p="p3" id="p-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        <sentence a="c" id="s-[0-9a-f]{8}-[0-9a-f]{8}-[0-9a-f]{8}">
+        c
+        </sentence>
+        </paragraph>
+        </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: Default elements and other default options; two consecutive runs with different result'
+  input:
+    cmdline: |
+      vrt-add-id in.vrt > out1.vrt;
+      vrt-add-id in.vrt > out2.vrt
+    shell: True
+    file:in.vrt: *input-para
+  output:
+    file:out1.vrt:
+    - name: 'two runs produce different result (random seed, hash)'
+      test: '!='
+      value:
+        file: out2.vrt
+  transform:
+  # Cannot use *transform-fast-t2p3s3 here, as stderr output with
+  # --verbose is doubled because of two commands
+  - {}
+  # Test that the command with --no-optimize produces the same result
+  - *transf-no-optimize
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  # Test the command with --verbose --no-optimize
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+
+- name: 'vrt-add-id: Default elements and other default options, no paragraphs in input'
+  input:
+    cmdline: vrt-add-id
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-para-default-regex
+      test: regex
+      transform-expected:
+        shell: grep -v "paragraph"
+  transform:
+  - {}
+  - *transf-no-optimize
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of not finding elements paragraph
+        vrt-add-id: added 2 text ids, 0 paragraph ids, 3 sentence ids
+  # Test the command with --verbose --no-optimize
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 0 paragraph ids, 3 sentence ids
+
+- name: 'vrt-add-id: Default elements, fixed seed and hash'
+  input:
+    cmdline: vrt-add-id --seed=1 --hash=1
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-356a192b-7a6e75f5">
+      <paragraph p="p1" id="p-356a192b-7a6e75f5-1df61006">
+      <sentence a="a" id="s-356a192b-7a6e75f5-db4ffcbb">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-356a192b-7a6e75f5-01b93e63">
+      <sentence a="b" id="s-356a192b-7a6e75f5-8404ee9d">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-356a192b-b2b32f50">
+      <paragraph p="p3" id="p-356a192b-b2b32f50-162be86a">
+      <sentence a="c" id="s-356a192b-b2b32f50-938b5cba">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: Default elements, fixed seed and hash, --type=counter, --start'
+  input:
+    cmdline: vrt-add-id --seed=1 --hash=1 --type=counter --start=10
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-356a192b-10">
+      <paragraph p="p1" id="p-356a192b-10-10">
+      <sentence a="a" id="s-356a192b-10-10">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-356a192b-10-11">
+      <sentence a="b" id="s-356a192b-10-11">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-356a192b-11">
+      <paragraph p="p3" id="p-356a192b-11-12">
+      <sentence a="c" id="s-356a192b-11-12">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: Default elements, fixed seed and hash, --max'
+  input:
+    cmdline: vrt-add-id --seed=1 --hash=1 --max=2^16
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-356a192b-f4dc">
+      <paragraph p="p1" id="p-356a192b-f4dc-f4cb">
+      <sentence a="a" id="s-356a192b-f4dc-16a6">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-356a192b-f4dc-3bec">
+      <sentence a="b" id="s-356a192b-f4dc-ddd8">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-356a192b-c2c0">
+      <paragraph p="p3" id="p-356a192b-c2c0-95da">
+      <sentence a="c" id="s-356a192b-c2c0-0372">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: Default elements, fixed seed and hash, --format'
+  input:
+    cmdline: vrt-add-id --seed=1 --hash=1 --format='{hash:.6}-{idnum[text]}-{id}'
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="356a19-7a6e75f5-7a6e75f5">
+      <paragraph p="p1" id="356a19-7a6e75f5-1df61006">
+      <sentence a="a" id="356a19-7a6e75f5-db4ffcbb">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="356a19-7a6e75f5-01b93e63">
+      <sentence a="b" id="356a19-7a6e75f5-8404ee9d">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="356a19-b2b32f50-b2b32f50">
+      <paragraph p="p3" id="356a19-b2b32f50-162be86a">
+      <sentence a="c" id="356a19-b2b32f50-938b5cba">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: Default elements, fixed seed and hash, --format, --max'
+  input:
+    cmdline: vrt-add-id --seed=1 --hash=1 --format='{hash:.6}-{idnum[text]}-{id}' --max=2^16
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="356a19-f4dc-f4dc">
+      <paragraph p="p1" id="356a19-f4dc-f4cb">
+      <sentence a="a" id="356a19-f4dc-16a6">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="356a19-f4dc-3bec">
+      <sentence a="b" id="356a19-f4dc-ddd8">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="356a19-c2c0-c2c0">
+      <paragraph p="p3" id="356a19-c2c0-95da">
+      <sentence a="c" id="356a19-c2c0-0372">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1396,7 +1396,7 @@
       stderr:
         replace:
         - '/\{paragraph/{text/'
-        - "/'paragraph/b'z"
+        - "/'paragraph/'z"
   - *transf-no-optimize
 
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -56,13 +56,17 @@
     name: --no-optimize
     input: &cmdline-no-optimize
       cmdline:
-        append: ' --no-optimize'
+        # Unlike appending, this works also if the command line ends
+        # with redirection or contains multiple commands
+        replace: '/vrt-add-id/vrt-add-id --no-optimize/'
   # Test the command with --verbose
   - &transf-verbose-fast-s3
     name: --verbose
     input: &cmdline-verbose
       cmdline:
-        append: ' --verbose'
+        # This works also if the command line ends with redirection,
+        # but multiple commands would require multiplying stderr
+        replace: '/vrt-add-id/vrt-add-id --verbose/'
     output-expected:
       stderr: |
         vrt-add-id: using the faster method
@@ -72,7 +76,9 @@
     name: --verbose --no-optimize
     input: &cmdline-verbose-no-optimize
       cmdline:
-        append: ' --verbose --no-optimize'
+        # This works also if the command line ends with redirection,
+        # but multiple commands would require multiplying stderr
+        replace: '/vrt-add-id/vrt-add-id --verbose --no-optimize/'
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --no-optimize

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -296,6 +296,12 @@
       c
       </sentence>
       </text>
+  # Check that the command with --no-optimize produces the same result
+  transform: &no-optimize
+  - {}
+  - input:
+      cmdline:
+        append: ' --no-optimize'
 
 
 - name: 'vrt-add-id: --type=random (implicit random seed)'
@@ -319,6 +325,7 @@
         c
         </sentence>
         </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --seed="" (explicit random seed)'
   input:
@@ -326,6 +333,7 @@
     stdin: *input-1
   output:
     stdout: *output-random
+  transform: *no-optimize
 
 
 - name: 'vrt-add-id: --type=random --seed=1'
@@ -348,6 +356,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 
 # --type=random --end
@@ -372,6 +381,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --end=20 (decimal, values of 2 hex digits)'
   input:
@@ -393,6 +403,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --end=0x1000 (hex, values of 3 hex digits)'
   input:
@@ -414,6 +425,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --end=2^8 (power, values of 2 hex digits)'
   input:
@@ -435,6 +447,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --end=2 (too small value)'
   input:
@@ -456,6 +469,7 @@
       vrt-add-id: more than 2 elements encountered; please increase --end
       vrt-add-id: non-zero status 1
     returncode: 1
+  transform: *no-optimize
 
 
 # --format
@@ -480,6 +494,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=counter --format --prefix'
   input:
@@ -501,6 +516,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --format'
   input:
@@ -522,6 +538,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --format --prefix'
   input:
@@ -543,6 +560,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --type=random --format; double {id}'
   input:
@@ -564,6 +582,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 
 # --hash
@@ -588,6 +607,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --hash; format with {hash1}'
   input:
@@ -595,6 +615,7 @@
     stdin: *input-1
   output:
     stdout: *output-hash
+  transform: *no-optimize
 
 - name: 'vrt-add-id: Multiple --hash'
   input:
@@ -616,6 +637,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: Format refers to non-existent {hashN}'
   input:
@@ -628,6 +650,7 @@
     stderr:
       contains: "KeyError: 'hash2'"
     returncode: 1
+  transform: *no-optimize
 
 
 # --format containing {elem[attr]}
@@ -652,6 +675,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
   input:
@@ -699,6 +723,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 
 # Format with "{this[attr]}"
@@ -723,6 +748,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
   input:
@@ -770,6 +796,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 
 # Multiple different elements
@@ -800,6 +827,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
@@ -827,6 +855,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text, paragraph, sentence with default options'
   input:
@@ -854,6 +883,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text, paragraph, sentence with some common options'
   input:
@@ -881,6 +911,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids'
   input:
@@ -908,6 +939,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 
 # --rename
@@ -946,6 +978,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --rename without argument, existing attribute'
   input:
@@ -967,6 +1000,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --rename fixed name, existing attribute'
   input:
@@ -988,6 +1022,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --rename with {}, text and sentence, existing attributes'
   input:
@@ -1009,6 +1044,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text and sentence, different renames, existing attributes'
   input:
@@ -1030,6 +1066,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 - name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
   input:
@@ -1051,6 +1088,7 @@
       c
       </sentence>
       </text>
+  transform: *no-optimize
 
 
 # Subtitutions in formats
@@ -1081,6 +1119,7 @@
       </sentence>
       </paragraph>
       </text>
+  transform: *no-optimize
 
 
 # idnum[elem] in format
@@ -1093,3 +1132,4 @@
     # This is another way to achieve the same result as with the
     # substitutions above
     stdout: *output-para-subst
+  transform: *no-optimize

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1305,6 +1305,70 @@
       </text>
   transform: *transform-fast-s3
 
+- name: 'vrt-add-id: Random --hash (empty string)'
+  input:
+    cmdline: |
+      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out1.vrt;
+      vrt-add-id --type=counter --hash="" --format="{hash}-{id:03d}" in.vrt > out2.vrt
+    shell: True
+    file:in.vrt: *input-1
+  output:
+    file:out1.vrt:
+    - &output-hash-random-1
+      value: *output-hash
+      transform-actual:
+        replace: '/id="[0-9a-f]{40}-/id="a9993e364706816aba3e25717850c26c9cd0d89d-/'
+    - &output-hash-random-2
+      name: 'different result from a fixed hash'
+      test: '!='
+      value: *output-hash
+    - name: 'two runs with random hash produce different result'
+      test: '!='
+      value:
+        file: out2.vrt
+    file:out2.vrt:
+    - *output-hash-random-1
+    - *output-hash-random-2
+  transform:
+  # Cannot use *transform-fast-s3 here, as stderr output with
+  # --verbose is doubled because of two commands
+  - {}
+  # Test that the command with --no-optimize produces the same result
+  - *transf-no-optimize
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 3 sentence ids
+        vrt-add-id: using the faster method
+        vrt-add-id: added 3 sentence ids
+  # Test the command with --verbose --no-optimize
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 3 sentence ids
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 3 sentence ids
+
+- name: 'vrt-add-id: Two random hashes are different'
+  input:
+    cmdline: vrt-add-id --type=counter --hash="" --hash="" --format="{hash1}-{hash2}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout:
+    - value: *output-hash
+      transform-actual:
+        replace: '/id="([0-9a-f]{40}-){2}/id="a9993e364706816aba3e25717850c26c9cd0d89d-/'
+    - name: 'the two random hash values are different'
+      test: python
+      value: |
+        mo = re.search('id="([0-9a-f]{40})-([0-9a-f]{40})-', value)
+        return mo and mo.group(1) != mo.group(2)
+  transform: *transform-fast-s3
+
 - name: 'vrt-add-id: Format refers to {hash} with no --hash options'
   input:
     cmdline: vrt-add-id --type=counter --format="{hash:.4}"

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -276,9 +276,9 @@
 # Tests for functionality added by Jyrki Niemi
 
 
-- name: 'vrt-add-id: --counter (default)'
+- name: 'vrt-add-id: --type=counter (default)'
   input:
-    cmdline: vrt-add-id --counter --element=text --id=n --start=0 --prefix=t- --force
+    cmdline: vrt-add-id --type=counter --element=text --id=n --start=0 --prefix=t- --force
     stdin: *input-1
   output:
     stdout: |
@@ -298,9 +298,9 @@
       </text>
 
 
-- name: 'vrt-add-id: --random (implicit random seed)'
+- name: 'vrt-add-id: --type=random (implicit random seed)'
   input:
-    cmdline: vrt-add-id --random
+    cmdline: vrt-add-id --type=random
     stdin: *input-1
   output:
     stdout: &output-random
@@ -320,17 +320,17 @@
         </sentence>
         </text>
 
-- name: 'vrt-add-id: --random --seed="" (explicit random seed)'
+- name: 'vrt-add-id: --type=random --seed="" (explicit random seed)'
   input:
-    cmdline: vrt-add-id --random --seed=""
+    cmdline: vrt-add-id --type=random --seed=""
     stdin: *input-1
   output:
     stdout: *output-random
 
 
-- name: 'vrt-add-id: --random --seed=1'
+- name: 'vrt-add-id: --type=random --seed=1'
   input:
-    cmdline: vrt-add-id --random --seed=1
+    cmdline: vrt-add-id --type=random --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -350,11 +350,11 @@
       </text>
 
 
-# --random --end
+# --type=random --end
 
-- name: 'vrt-add-id: --random --end=3'
+- name: 'vrt-add-id: --type=random --end=3'
   input:
-    cmdline: vrt-add-id --random --end=3 --seed=1
+    cmdline: vrt-add-id --type=random --end=3 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -373,9 +373,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --end=20 (decimal, values of 2 hex digits)'
+- name: 'vrt-add-id: --type=random --end=20 (decimal, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --random --end=20 --seed=1
+    cmdline: vrt-add-id --type=random --end=20 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -394,9 +394,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --end=0x1000 (hex, values of 3 hex digits)'
+- name: 'vrt-add-id: --type=random --end=0x1000 (hex, values of 3 hex digits)'
   input:
-    cmdline: vrt-add-id --random --end=0x1000 --seed=1
+    cmdline: vrt-add-id --type=random --end=0x1000 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -415,9 +415,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --end=2^8 (power, values of 2 hex digits)'
+- name: 'vrt-add-id: --type=random --end=2^8 (power, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --random --end=2^8 --seed=1
+    cmdline: vrt-add-id --type=random --end=2^8 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -436,9 +436,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --end=2 (too small value)'
+- name: 'vrt-add-id: --type=random --end=2 (too small value)'
   input:
-    cmdline: vrt-add-id --random --end=2 --seed=1
+    cmdline: vrt-add-id --type=random --end=2 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -460,9 +460,9 @@
 
 # --format
 
-- name: 'vrt-add-id: --counter --format'
+- name: 'vrt-add-id: --type=counter --format'
   input:
-    cmdline: vrt-add-id --counter --start=10 --format="*{id:03x}*"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*"
     stdin: *input-1
   output:
     stdout: |
@@ -481,9 +481,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --counter --format --prefix'
+- name: 'vrt-add-id: --type=counter --format --prefix'
   input:
-    cmdline: vrt-add-id --counter --start=10 --format="*{id:03x}*" --prefix="x-"
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*" --prefix="x-"
     stdin: *input-1
   output:
     stdout: |
@@ -502,9 +502,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --format'
+- name: 'vrt-add-id: --type=random --format'
   input:
-    cmdline: vrt-add-id --random --seed=1 --end=10 --format="*{id:03d}*"
+    cmdline: vrt-add-id --type=random --seed=1 --end=10 --format="*{id:03d}*"
     stdin: *input-1
   output:
     stdout: |
@@ -523,9 +523,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --format --prefix'
+- name: 'vrt-add-id: --type=random --format --prefix'
   input:
-    cmdline: vrt-add-id --random --seed=1 --end=10 --format="*{id:03d}*" --prefix="x-"
+    cmdline: vrt-add-id --type=random --seed=1 --end=10 --format="*{id:03d}*" --prefix="x-"
     stdin: *input-1
   output:
     stdout: |
@@ -544,9 +544,9 @@
       </sentence>
       </text>
 
-- name: 'vrt-add-id: --random --format; double {id}'
+- name: 'vrt-add-id: --type=random --format; double {id}'
   input:
-    cmdline: vrt-add-id --random --seed=1 --end=100 --format="*{id:03d}-{id:02x}*"
+    cmdline: vrt-add-id --type=random --seed=1 --end=100 --format="*{id:03d}-{id:02x}*"
     stdin: *input-1
   output:
     stdout: |
@@ -570,7 +570,7 @@
 
 - name: 'vrt-add-id: --hash; format with {hash}'
   input:
-    cmdline: vrt-add-id --counter --hash=abc --format="{hash}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash}-{id:03d}"
     stdin: *input-1
   output:
     stdout: &output-hash |
@@ -591,14 +591,14 @@
 
 - name: 'vrt-add-id: --hash; format with {hash1}'
   input:
-    cmdline: vrt-add-id --counter --hash=abc --format="{hash1}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1}-{id:03d}"
     stdin: *input-1
   output:
     stdout: *output-hash
 
 - name: 'vrt-add-id: Multiple --hash'
   input:
-    cmdline: vrt-add-id --counter --hash=abc --hash=def --hash=ghi --format="{hash1:.4}-{hash2:.4}-{hash3:.6}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --hash=def --hash=ghi --format="{hash1:.4}-{hash2:.4}-{hash3:.6}-{id:03d}"
     stdin: *input-1
   output:
     stdout: |
@@ -619,7 +619,7 @@
 
 - name: 'vrt-add-id: Format refers to non-existent {hashN}'
   input:
-    cmdline: vrt-add-id --counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}"
     stdin: *input-1
   output:
     stdout: |
@@ -634,7 +634,7 @@
 
 - name: 'vrt-add-id: --format with {elem[attr]}'
   input:
-    cmdline: vrt-add-id --counter --format="{sentence[a]}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --format="{sentence[a]}-{id:03d}"
     stdin: *input-1
   output:
     stdout: |
@@ -655,7 +655,7 @@
 
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
   input:
-    cmdline: vrt-add-id --counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}"
+    cmdline: vrt-add-id --type=counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}"
     stdin: &input-para |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
@@ -705,7 +705,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with completely different options'
   input:
-    cmdline: vrt-add-id --element=text --counter --start=0 --id=tid --element=paragraph --counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --random --id=sid --seed=0 --end=2^16 --format="{id:04x}"
+    cmdline: vrt-add-id --element=text --type=counter --start=0 --id=tid --element=paragraph --type=counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --type=random --id=sid --seed=0 --end=2^16 --format="{id:04x}"
     stdin: *input-para
   output:
     stdout: |
@@ -732,7 +732,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
-    cmdline: vrt-add-id --id=xid --random --seed=0 --end=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
+    cmdline: vrt-add-id --id=xid --type=random --seed=0 --end=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
     stdin: *input-para
   output:
     stdout: |
@@ -786,7 +786,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with some common options'
   input:
-    cmdline: vrt-add-id --id=id --random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
     stdin: *input-para
   output:
     stdout: |

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -12,12 +12,12 @@
 
 
 # Tests for the functionality of the original script by Jussi
-# Piitulainen
+# Piitulainen (but with --type=random as the default)
 
 
-- name: 'vrt-add-id: Default options'
+- name: 'vrt-add-id: Default options + --type=counter'
   input:
-    cmdline: vrt-add-id
+    cmdline: vrt-add-id --type=counter
     stdin: &input-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
@@ -79,9 +79,33 @@
         vrt-add-id: added 3 sentence ids
 
 
+- name: 'vrt-add-id: Default options'
+  input:
+    cmdline: vrt-add-id
+    stdin: *input-1
+  output:
+    stdout:
+      regex: |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1">
+        <sentence a="a" id="[0-9a-f]{8}">
+        a
+        </sentence>
+        <sentence a="b" id="[0-9a-f]{8}">
+        b
+        </sentence>
+        </text>
+        <text n="2">
+        <sentence a="c" id="[0-9a-f]{8}">
+        c
+        </sentence>
+        </text>
+  transform: *transform-fast-s3
+
+
 - name: 'vrt-add-id: --element=text'
   input:
-    cmdline: vrt-add-id --element="text"
+    cmdline: vrt-add-id --type=counter --element="text"
     stdin: *input-1
   output:
     stdout: |
@@ -120,7 +144,7 @@
 
 - name: 'vrt-add-id: Non-existent element (no change)'
   input:
-    cmdline: vrt-add-id --element=x
+    cmdline: vrt-add-id --type=counter --element=x
     stdin: *input-1
   output:
     stdout: *input-1
@@ -143,7 +167,7 @@
 
 - name: 'vrt-add-id: --id'
   input:
-    cmdline: vrt-add-id --id="sid"
+    cmdline: vrt-add-id --type=counter --id="sid"
     stdin: *input-1
   output:
     stdout: |
@@ -166,7 +190,7 @@
 
 - name: 'vrt-add-id: --start=0'
   input:
-    cmdline: vrt-add-id --start=0
+    cmdline: vrt-add-id --type=counter --start=0
     stdin: *input-1
   output:
     stdout: |
@@ -189,7 +213,7 @@
 
 - name: 'vrt-add-id: --prefix'
   input:
-    cmdline: vrt-add-id --prefix=s-
+    cmdline: vrt-add-id --type=counter --prefix=s-
     stdin: *input-1
   output:
     stdout: |
@@ -212,7 +236,7 @@
 
 - name: 'vrt-add-id: --sort'
   input:
-    cmdline: vrt-add-id --element=text --sort
+    cmdline: vrt-add-id --type=counter --element=text --sort
     stdin: *input-1
   output:
     stdout: |
@@ -248,7 +272,7 @@
 
 - name: 'vrt-add-id: Existing id attribute (without --force)'
   input:
-    cmdline: vrt-add-id --id=a
+    cmdline: vrt-add-id --type=counter --id=a
     stdin: *input-1
   output:
     stdout: |
@@ -274,7 +298,7 @@
 
 - name: 'vrt-add-id: Overwrite existing id attribute with --force'
   input:
-    cmdline: vrt-add-id --id=a --force
+    cmdline: vrt-add-id --type=counter --id=a --force
     stdin: *input-1
   output:
     stdout: |
@@ -306,7 +330,7 @@
 
 - name: 'vrt-add-id: All options'
   input:
-    cmdline: vrt-add-id --element=text --id=n --start=0 --prefix=t- --force
+    cmdline: vrt-add-id --type=counter --element=text --id=n --start=0 --prefix=t- --force
     stdin: *input-1
   output:
     stdout: |
@@ -387,7 +411,7 @@
 # Tests for functionality added by Jyrki Niemi
 
 
-- name: 'vrt-add-id: --type=counter (default)'
+- name: 'vrt-add-id: --type=counter'
   input:
     cmdline: vrt-add-id --type=counter --element=text --id=n --start=0 --prefix=t- --force
     stdin: *input-1
@@ -1455,6 +1479,35 @@
     cmdline: vrt-add-id --element=text --element=paragraph --element=sentence
     stdin: *input-para
   output:
+    stdout:
+      regex: |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1" id="[0-9a-f]{8}">
+        <paragraph p="p1" id="[0-9a-f]{8}">
+        <sentence a="a" id="[0-9a-f]{8}">
+        a
+        </sentence>
+        </paragraph>
+        <paragraph p="p2" id="[0-9a-f]{8}">
+        <sentence a="b" id="[0-9a-f]{8}">
+        b
+        </sentence>
+        </paragraph>
+        </text>
+        <text n="2" id="[0-9a-f]{8}">
+        <paragraph p="p3" id="[0-9a-f]{8}">
+        <sentence a="c" id="[0-9a-f]{8}">
+        c
+        </sentence>
+        </paragraph>
+        </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: text, paragraph, sentence with default options + --type=counter'
+  input:
+    cmdline: vrt-add-id --type=counter --element=text --element=paragraph --element=sentence
+    stdin: *input-para
+  output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1" id="1">
@@ -1548,7 +1601,7 @@
 
 - name: 'vrt-add-id: --rename, no existing attribute'
   input:
-    cmdline: vrt-add-id --id=x --rename
+    cmdline: vrt-add-id --type=counter --id=x --rename
     stdin: &input-multiattr |
       <!-- #vrt positional-attributes: word -->
       <text a="a" n="1" n_1="a" n_2="b">
@@ -1593,7 +1646,7 @@
 
 - name: 'vrt-add-id: --rename without argument, existing attribute'
   input:
-    cmdline: vrt-add-id --id=a --rename
+    cmdline: vrt-add-id --type=counter --id=a --rename
     stdin: *input-multiattr
   output:
     stdout: |
@@ -1615,7 +1668,7 @@
 
 - name: 'vrt-add-id: --rename fixed name, existing attribute'
   input:
-    cmdline: vrt-add-id --id=a --rename=b
+    cmdline: vrt-add-id --type=counter --id=a --rename=b
     stdin: *input-multiattr
   output:
     stdout: |
@@ -1637,7 +1690,7 @@
 
 - name: 'vrt-add-id: --rename with {}, text and sentence, existing attributes'
   input:
-    cmdline: vrt-add-id --rename="{}_" --element=text --id=n_1 --element=sentence --id=a
+    cmdline: vrt-add-id --type=counter --rename="{}_" --element=text --id=n_1 --element=sentence --id=a
     stdin: *input-multiattr
   output:
     stdout: |
@@ -1659,7 +1712,7 @@
 
 - name: 'vrt-add-id: text and sentence, different renames, existing attributes'
   input:
-    cmdline: vrt-add-id --element=text --id=n_1 --rename="{}_" --element=sentence --id=a --rename="{}a"
+    cmdline: vrt-add-id --type=counter --element=text --id=n_1 --rename="{}_" --element=sentence --id=a --rename="{}a"
     stdin: *input-multiattr
   output:
     stdout: |
@@ -1696,7 +1749,7 @@
 
 - name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
   input:
-    cmdline: vrt-add-id --element=text --id=a --rename=n --element=sentence --id=a --rename=id
+    cmdline: vrt-add-id --type=counter --element=text --id=a --rename=n --element=sentence --id=a --rename=id
     stdin: *input-multiattr
   output:
     stdout: |
@@ -1794,7 +1847,7 @@
 
 - name: 'vrt-add-id: --verbose; {id} with different format specifications (faster method)'
   input:
-    cmdline: vrt-add-id --format="{id:d}" --verbose
+    cmdline: vrt-add-id --type=counter --format="{id:d}" --verbose
     stdin: *input-1
   output:
     stdout: *output-1-s3
@@ -1855,7 +1908,7 @@
 
 - name: 'vrt-add-id: --verbose; {id} with different format specifications (slower method)'
   input:
-    cmdline: vrt-add-id --format="{id:<1d}" --verbose
+    cmdline: vrt-add-id --type=counter --format="{id:<1d}" --verbose
     stdin: *input-1
   output:
     stdout: *output-1-s3
@@ -1917,7 +1970,7 @@
 
 - name: 'vrt-add-id: --verbose; slower method because not all types of elements occurred in input'
   input:
-    cmdline: vrt-add-id --verbose --element=sentence --element=paragraph --element=x
+    cmdline: vrt-add-id --type=counter --verbose --element=sentence --element=paragraph --element=x
     stdin: *input-1
   output:
     stdout: *output-1-s3

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -546,7 +546,7 @@
     cmdline: vrt-add-id --type=random --max=0x1000 --seed=1
     stdin: *input-1
   output:
-    stdout: |
+    stdout: &stdout-random-4096-seed-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
       <sentence a="a" id="568">
@@ -580,6 +580,105 @@
       </text>
       <text n="2">
       <sentence a="c" id="8a">
+      c
+      </sentence>
+      </text>
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:03x)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03x}'
+    stdin: *input-1
+  output:
+    stdout: *stdout-random-4096-seed-1
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:03X)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:03X}'
+    stdin: *input-1
+  output:
+    stdout:
+      value: *stdout-random-4096-seed-1
+      transform-expected:
+        python: |
+          return re.sub(r'id="(...)"',
+                        lambda mo: f'id="{mo.group(1).upper()}"',
+                        value)
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:#05x)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:#05x}'
+    stdin: *input-1
+  output:
+    stdout:
+      value: *stdout-random-4096-seed-1
+      transform-expected:
+        replace: '/id="/id="0x/'
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:04o)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:04o}'
+    stdin: *input-1
+  output:
+    stdout:
+      value: *stdout-random-4096-seed-1
+      transform-expected:
+        python: |
+          return re.sub(r'id="(...)"',
+                        lambda mo: f'id="{int(mo.group(1), 16):04o}"',
+                        value)
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:012b)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:012b}'
+    stdin: *input-1
+  output:
+    stdout:
+      value: *stdout-random-4096-seed-1
+      transform-expected:
+        python: |
+          return re.sub(r'id="(...)"',
+                        lambda mo: f'id="{int(mo.group(1), 16):012b}"',
+                        value)
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:/>12b)'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --format='{id:/>12b}'
+    stdin: *input-1
+  output:
+    stdout:
+      value: *stdout-random-4096-seed-1
+      transform-expected:
+        python: |
+          return re.sub(r'id="(...)"',
+                        lambda mo: f'id="{int(mo.group(1), 16):/>12b}"',
+                        value)
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: --type=random --max from format (:04d)'
+  input:
+    cmdline:
+    - vrt-add-id --type=random --seed=1 --format='{id:04d}'
+    - vrt-add-id --type=random --seed=1 --format='{id:04}'
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="2768">
+      a
+      </sentence>
+      <sentence a="b" id="6058">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="4446">
       c
       </sentence>
       </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1854,6 +1854,76 @@
     stdout: *output-para-subst
   transform: *transform-fast-t2p3s3
 
+- name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph but previous paragraphs'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin:
+      value: *input-para
+      transform:
+        # Remove the last paragraph tags
+        shell: |
+          grep -v 'p="p3"' | head -n-2;
+          echo "</text>"
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-b92f-f4dc">
+      <sentence a="a" id="s-b92f+f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-b92f-f4cb">
+      <sentence a="b" id="s-b92f+f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-294c">
+      <sentence a="c" id="s-294c+f4cb-1f16">
+      c
+      </sentence>
+      </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids, 2 paragraph ids, 3 sentence ids
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 2 paragraph ids, 3 sentence ids
+
+- name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph without previous paragraphs'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin:
+      value: *input-para
+      transform:
+        # Remove the first paragraph tags
+        shell: |
+          awk '/p="p1"/ {next} /<\/paragraph>/ && ! p {p = 1; next} {print}'
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+    stderr: |
+      vrt-add-id: format replacement field s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}: key 'paragraph' not found
+      vrt-add-id: non-zero status 1
+    returncode: 1
+  transform:
+  - {}
+  - *transf-no-optimize
+  - name: --verbose
+    input: *cmdline-verbose
+  - *transf-verbose-noopt-prepend
+
 
 # --verbose (and optimization)
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1107,6 +1107,88 @@
       stderr:
         replace: '/faster method/slower method because of --no-optimize/'
 
+- name: 'vrt-add-id: Format containing fixed characters to be XML-encoded'
+  input:
+    cmdline: vrt-add-id --type=counter --format="<{id}" --verbose
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/(id=")/\1&lt;/'
+    stderr: |
+      vrt-add-id: using the faster method
+      vrt-add-id: added 3 sentence ids
+  transform:
+  - name: 'format containing "<"'
+    # The values above
+  - name: 'format containing ">"'
+    input:
+      cmdline:
+        replace: '/</>/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&gt;/'
+  - name: 'format containing "&"'
+    input:
+      cmdline:
+        replace: '/</&/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&amp;/'
+  - name: 'format containing "\""'
+    input:
+      cmdline:
+        replace: '/</\"/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&quot;/'
+  - *transf-verbose-noopt-s3
+
+- name: 'vrt-add-id: Format spec producing characters to be XML-encoded'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{id:<>2d}" --verbose
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/(id=")/\1&lt;/'
+    stderr: |
+      vrt-add-id: using the slower method because of format producing '<'
+      vrt-add-id: added 3 sentence ids
+  transform:
+  - name: 'format containing "<"'
+    # The values above
+  - name: 'format containing ">"'
+    input:
+      cmdline:
+        replace: '/</>/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&gt;/'
+      stderr:
+        replace: '/</>/'
+  - name: 'format containing "&"'
+    input:
+      cmdline:
+        replace: '/</&/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&amp;/'
+      stderr:
+        replace: '/</&/'
+  - name: 'format containing "\""'
+    input:
+      cmdline:
+        replace: '/</\"/'
+    output-expected:
+      stdout:
+        replace: '/&lt;/&quot;/'
+      stderr:
+        replace: '/</"/'
+  - *transf-verbose-noopt-s3
+
 
 # --hash
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -628,3 +628,27 @@
     stderr:
       contains: "KeyError: 'hash2'"
     returncode: 1
+
+
+# --format containing {elem[attr]}
+
+- name: 'vrt-add-id: --format with {elem[attr]}'
+  input:
+    cmdline: vrt-add-id --counter --format="{sentence[a]}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="a-001">
+      a
+      </sentence>
+      <sentence a="b" id="b-002">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="c-003">
+      c
+      </sentence>
+      </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1375,14 +1375,14 @@
 
 - name: 'vrt-add-id: --format referring to non-existent element or attribute'
   input:
-    cmdline: vrt-add-id --format="{paragraph[z]}"
+    cmdline: vrt-add-id --format="{id}-{paragraph[z]}"
     stdin: *input-1
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
     stderr: |
-      vrt-add-id: format replacement field {paragraph[z]}: key 'paragraph' not found
+      vrt-add-id: format replacement field {id}-{paragraph[z]}: key 'paragraph' not found
       vrt-add-id: non-zero status 1
     returncode: 1
   transform:
@@ -1397,6 +1397,19 @@
         replace:
         - '/\{paragraph/{text/'
         - "/'paragraph/'z"
+  - *transf-no-optimize
+
+- name: 'vrt-add-id: --format not referring to id or idnum[elem]'
+  input:
+    cmdline: vrt-add-id --seed=1 --element=text --format="{id:08x}" --element=sentence --format="{idnum[text]}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: format string for element "sentence" must contain replacement field "id" or "idnum[sentence]": {idnum[text]}
+    returncode: 1
+  transform:
+  - {}
   - *transf-no-optimize
 
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -34,7 +34,7 @@
       </sentence>
       </text>
   output:
-    stdout: |
+    stdout: &output-1-s3 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
       <sentence a="a" id="1">
@@ -49,6 +49,33 @@
       c
       </sentence>
       </text>
+  transform: &transform-fast-s3
+  - {}
+  # Test that the command with --no-optimize produces the same result
+  - &transf-no-optimize
+    input: &cmdline-no-optimize
+      cmdline:
+        append: ' --no-optimize'
+  # Test the command with --verbose
+  - &transf-verbose-fast-s3
+    input: &cmdline-verbose
+      cmdline:
+        append: ' --verbose'
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the faster method
+          vrt-add-id: added 3 sentence ids
+  # Test the command with --verbose --no-optimize
+  - &transf-verbose-noopt-s3
+    input: &cmdline-verbose-no-optimize
+      cmdline:
+        append: ' --verbose --no-optimize'
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 3 sentence ids
 
 
 - name: 'vrt-add-id: --element=text'
@@ -71,6 +98,23 @@
       c
       </sentence>
       </text>
+  transform: &transform-fast-t2
+  - {}
+  - *transf-no-optimize
+  - &transf-verbose-fast-t2
+    input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the faster method
+          vrt-add-id: added 2 text ids
+  - &transf-verbose-noopt-t2
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 2 text ids
 
 
 - name: 'vrt-add-id: Non-existent element (no change)'
@@ -79,6 +123,21 @@
     stdin: *input-1
   output:
     stdout: *input-1
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of not finding elements x
+          vrt-add-id: added 0 x ids
+  - input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 0 x ids
 
 
 - name: 'vrt-add-id: --id'
@@ -101,6 +160,7 @@
       c
       </sentence>
       </text>
+  transform: *transform-fast-s3
 
 
 - name: 'vrt-add-id: --start=0'
@@ -123,6 +183,7 @@
       c
       </sentence>
       </text>
+  transform: *transform-fast-s3
 
 
 - name: 'vrt-add-id: --prefix'
@@ -145,6 +206,7 @@
       c
       </sentence>
       </text>
+  transform: *transform-fast-s3
 
 
 - name: 'vrt-add-id: --sort'
@@ -167,6 +229,16 @@
       c
       </sentence>
       </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --sort
+          vrt-add-id: added 2 text ids
+  - *transf-verbose-noopt-t2
 
 
 - name: 'vrt-add-id: Existing id attribute (without --force)'
@@ -181,6 +253,17 @@
       vrt-add-id: element has id already
       vrt-add-id: non-zero status 1
     returncode: 1
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+  - &transf-verbose-noopt-prepend
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        prepend: |
+          vrt-add-id: using the slower method because of --no-optimize
+
 
 - name: 'vrt-add-id: Overwrite existing id attribute with --force'
   input:
@@ -202,6 +285,16 @@
       c
       </sentence>
       </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --force
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 
 - name: 'vrt-add-id: All options'
@@ -224,6 +317,17 @@
       c
       </sentence>
       </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - &transf-verbose-force-t2
+    input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --force
+          vrt-add-id: added 2 text ids
+  - *transf-verbose-noopt-t2
 
 
 # Invalid option values
@@ -297,11 +401,11 @@
       </sentence>
       </text>
   # Check that the command with --no-optimize produces the same result
-  transform: &no-optimize
+  transform:
   - {}
-  - input:
-      cmdline:
-        append: ' --no-optimize'
+  - *transf-no-optimize
+  - *transf-verbose-force-t2
+  - *transf-verbose-noopt-t2
 
 
 - name: 'vrt-add-id: --type=random (implicit random seed)'
@@ -325,7 +429,8 @@
         c
         </sentence>
         </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
+
 
 - name: 'vrt-add-id: --type=random --seed="" (explicit random seed)'
   input:
@@ -333,7 +438,7 @@
     stdin: *input-1
   output:
     stdout: *output-random
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 
 - name: 'vrt-add-id: --type=random --seed=1'
@@ -356,7 +461,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 
 # --type=random --end
@@ -381,7 +486,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --end=20 (decimal, values of 2 hex digits)'
   input:
@@ -403,7 +508,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --end=0x1000 (hex, values of 3 hex digits)'
   input:
@@ -425,7 +530,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --end=2^8 (power, values of 2 hex digits)'
   input:
@@ -447,7 +552,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --end=2 (too small value)'
   input:
@@ -469,7 +574,16 @@
       vrt-add-id: more than 2 elements encountered; please increase --end
       vrt-add-id: non-zero status 1
     returncode: 1
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - &transf-verbose-fast-prepend
+    input: *cmdline-verbose
+    output-expected:
+      stderr:
+        prepend: |
+          vrt-add-id: using the faster method
+  - *transf-verbose-noopt-prepend
 
 
 # --format
@@ -494,7 +608,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=counter --format without width'
   input:
@@ -516,7 +630,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=counter --format with width, default type'
   input:
@@ -538,7 +652,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=counter --format --prefix'
   input:
@@ -560,7 +674,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --format'
   input:
@@ -582,7 +696,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --format --prefix'
   input:
@@ -604,7 +718,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --type=random --format; double {id}'
   input:
@@ -626,7 +740,16 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of using {id} with different format specifications: 03d, 02x
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 
 # --hash
@@ -651,7 +774,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: --hash; format with {hash1}'
   input:
@@ -659,7 +782,7 @@
     stdin: *input-1
   output:
     stdout: *output-hash
-  transform: *no-optimize
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: Multiple --hash'
   input:
@@ -681,6 +804,7 @@
       c
       </sentence>
       </text>
+  transform: *transform-fast-s3
 
 - name: 'vrt-add-id: Format refers to {hash} with no --hash options'
   input:
@@ -691,7 +815,9 @@
     stderr: |
       vrt-add-id: error: invalid format replacement field as no --hash options were specified: {hash:.4}
     returncode: 1
-  transform: *no-optimize
+  transform: &no-optimize
+  - {}
+  - *transf-no-optimize
 
 - name: 'vrt-add-id: Format refers to non-existent {hashN}'
   input:
@@ -727,7 +853,16 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {sentence[a]}
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
   input:
@@ -775,7 +910,16 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[n]:0>2s}
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 
 # Format with "{this[attr]}"
@@ -800,7 +944,16 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[a]}
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
   input:
@@ -848,7 +1001,21 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[x]}
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  - input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
 
 
 # Invalid --format
@@ -882,6 +1049,7 @@
     output-expected:
       stderr:
         replace: '/\{a/{text[A]/'
+  - *transf-no-optimize
 
 - name: 'vrt-add-id: --format with idnum[elem] where no ids added to elem'
   input:
@@ -892,6 +1060,7 @@
     stderr: |
       vrt-add-id: error: elem in format replacement field idnum[elem] must be the name of one of the elements to which ids are added: {idnum[text]}
     returncode: 1
+  transform: *no-optimize
 
 - name: 'vrt-add-id: --format with substitution for int-valued field'
   input:
@@ -912,6 +1081,7 @@
           with: '{idnum[sentence]'
     output-expected:
       stderr: *repl-id-idnum-sent
+  - *transf-no-optimize
 
 - name: 'vrt-add-id: --format with presentation "s" for int-valued field'
   input:
@@ -1018,6 +1188,7 @@
         replace:
         - '/\{paragraph/{text/'
         - "/'paragraph/b'z"
+  - *transf-no-optimize
 
 
 # Multiple different elements
@@ -1048,7 +1219,23 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform: &transform-fast-t2p3s3
+  - {}
+  - *transf-no-optimize
+  - &transf-fast-t2p3s3
+    input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the faster method
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  - &transf-noopt-t2p3s3
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
@@ -1076,7 +1263,7 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-t2p3s3
 
 - name: 'vrt-add-id: text, paragraph, sentence with default options'
   input:
@@ -1104,14 +1291,14 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-t2p3s3
 
 - name: 'vrt-add-id: text, paragraph, sentence with some common options'
   input:
     cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
     stdin: *input-para
   output:
-    stdout: |
+    stdout: &output-para-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1" id="t-b1fd">
       <paragraph p="p1" id="p-b667">
@@ -1132,7 +1319,7 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform: *transform-fast-t2p3s3
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids'
   input:
@@ -1160,7 +1347,16 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]}
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  - *transf-noopt-t2p3s3
 
 
 # --rename
@@ -1199,7 +1395,16 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: &transform-rename-s3
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --rename
+          vrt-add-id: added 3 sentence ids
+  - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: --rename without argument, existing attribute'
   input:
@@ -1221,7 +1426,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-rename-s3
 
 - name: 'vrt-add-id: --rename fixed name, existing attribute'
   input:
@@ -1243,7 +1448,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-rename-s3
 
 - name: 'vrt-add-id: --rename with {}, text and sentence, existing attributes'
   input:
@@ -1287,7 +1492,22 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: &transform-rename-t2s3
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --rename
+          vrt-add-id: added 2 text ids, 3 sentence ids
+  - &transf-noopt-t2s3
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 2 text ids, 3 sentence ids
 
 - name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
   input:
@@ -1309,7 +1529,7 @@
       c
       </sentence>
       </text>
-  transform: *no-optimize
+  transform: *transform-rename-t2s3
 
 
 # Subtitutions in formats
@@ -1340,7 +1560,16 @@
       </sentence>
       </paragraph>
       </text>
-  transform: *no-optimize
+  transform:
+  - {}
+  - *transf-no-optimize
+  - input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]/t-//}
+          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  - *transf-noopt-t2p3s3
 
 
 # idnum[elem] in format
@@ -1353,4 +1582,144 @@
     # This is another way to achieve the same result as with the
     # substitutions above
     stdout: *output-para-subst
-  transform: *no-optimize
+  transform: *transform-fast-t2p3s3
+
+
+# --verbose (and optimization)
+
+# Note that many cases of --verbose are tested above using grouped
+# transformations
+
+- name: 'vrt-add-id: --verbose; text, paragraph, sentence with some common options'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2 --verbose
+    stdin: *input-para
+  output:
+    stdout: *output-para-1
+    stderr: |
+      vrt-add-id: using the faster method
+      vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  transform:
+  - {}
+  - input: *cmdline-no-optimize
+    output-expected:
+      stderr:
+        replace: '/faster method/slower method because of --no-optimize/'
+
+- name: 'vrt-add-id: --verbose; {id} with different format specifications (faster method)'
+  input:
+    cmdline: vrt-add-id --format="{id:d}" --verbose
+    stdin: *input-1
+  output:
+    stdout: *output-1-s3
+    stderr: &stderr-fast-s3 |
+      vrt-add-id: using the faster method
+      vrt-add-id: added 3 sentence ids
+  transform:
+  - {}
+  - input:
+      cmdline:
+      - replace: '/:d/:x/'
+  - input:
+      cmdline:
+      - replace: '/:d/:1/'
+  - input:
+      cmdline:
+      - replace: '/:d/:X/'
+  - input:
+      cmdline:
+      - replace: '/:d/:/'
+  - input:
+      cmdline:
+      - replace: '/:d/:2d/'
+    output-expected:
+      stdout:
+      - replace: '/id="/id=" /'
+  - input:
+      cmdline:
+      - replace: '/:d/:2/'
+    output-expected:
+      stdout:
+      - replace: '/id="/id=" /'
+  - input:
+      cmdline:
+      - replace: '/:d/:2x/'
+    output-expected:
+      stdout:
+      - replace: '/id="/id=" /'
+  - input:
+      cmdline:
+      - replace: '/:d/:03x/'
+    output-expected:
+      stdout:
+      - replace: '/id="/id="00/'
+  - input: *cmdline-no-optimize
+    output-expected:
+      stderr:
+        replace: '/faster method/slower method because of --no-optimize/'
+
+- name: 'vrt-add-id: --verbose; {id} with different format specifications (slower method)'
+  input:
+    cmdline: vrt-add-id --format="{id:<1d}" --verbose
+    stdin: *input-1
+  output:
+    stdout: *output-1-s3
+    stderr: |
+      vrt-add-id: using the slower method because of format specification not matching "[0-9]*[dxX]?": {id:<1d}
+      vrt-add-id: added 3 sentence ids
+  transform:
+  - {}
+  - input:
+      cmdline:
+        replace: '/<1/<5/'
+    output-expected:
+      stdout:
+        replace: '/(id=".)/\1    /'
+      stderr:
+        replace: '/<1/<5/'
+  - input:
+      cmdline:
+        replace: '/<1/>5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="    \1/'
+      stderr:
+        replace: '/<1/>5/'
+  - input:
+      cmdline:
+        replace: '/<1/^5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="  \1  /'
+      stderr:
+        replace: '/<1/^5/'
+  - input:
+      cmdline:
+        replace: '/<1/-^5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="--\1--/'
+      stderr:
+        replace: '/<1/-^5/'
+  - input:
+      cmdline:
+        replace: '/<1d/#04x/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="0x0\1/'
+      stderr:
+        replace: '/<1d/#04x/'
+  - input: *cmdline-no-optimize
+    output-expected:
+      stderr:
+        replace: '/format specification.*/--no-optimize/'
+
+- name: 'vrt-add-id: --verbose; slower method because not all types of elements occurred in input'
+  input:
+    cmdline: vrt-add-id --verbose --element=sentence --element=paragraph --element=x
+    stdin: *input-1
+  output:
+    stdout: *output-1-s3
+    stderr: |
+      vrt-add-id: using the slower method because of not finding elements paragraph, x
+      vrt-add-id: added 3 sentence ids, 0 paragraph ids, 0 x ids

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1189,6 +1189,61 @@
         replace: '/</"/'
   - *transf-verbose-noopt-s3
 
+- name: 'vrt-add-id: Format with literal { and }'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{{-{id}-}}"
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/id="(.)"/id="{-\1-}"/'
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: Format with literal "{id}"'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{{id}}-{id}"
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/id="(.)"/id="{id}-\1"/'
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: Format with literal "{idnum[...]}"'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{{idnum[sentence]}}-{{{{idnum[x]}}}}-{id}"
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/id="(.)"/id="{idnum[sentence]}-{{idnum[x]}}-\1"/'
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: Format with literal { and } immediately around replacement field'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{{{id}}}"
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/id="(.)"/id="{\1}"/'
+  transform: *transform-fast-s3
+
+- name: 'vrt-add-id: Format with literal {{ and }} immediately around replacement field'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{{{{{id}}}}}"
+    stdin: *input-1
+  output:
+    stdout:
+      value: *output-1-s3
+      transform-expected:
+        replace: '/id="(.)"/id="{{\1}}"/'
+  transform: *transform-fast-s3
+
 
 # --hash
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -637,6 +637,16 @@
       c
       </sentence>
       </text>
+
+- name: 'vrt-add-id: Format refers to {hash} with no --hash options'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{hash:.4}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: invalid format replacement field as no --hash options were specified: {hash:.4}
+    returncode: 1
   transform: *no-optimize
 
 - name: 'vrt-add-id: Format refers to non-existent {hashN}'
@@ -644,11 +654,9 @@
     cmdline: vrt-add-id --type=counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}"
     stdin: *input-1
   output:
-    stdout: |
-      <!-- #vrt positional-attributes: word -->
-      <text n="1">
-    stderr:
-      contains: "KeyError: 'hash2'"
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: invalid format replacement field as fewer than 2 --hash options were specified: {hash2:.4}
     returncode: 1
   transform: *no-optimize
 
@@ -797,6 +805,175 @@
       </paragraph>
       </text>
   transform: *no-optimize
+
+
+# Invalid --format
+
+- name: 'vrt-add-id: --format with unsupported replacement field'
+  input:
+    cmdline: vrt-add-id --format="{a}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: unsupported format replacement field: {a}
+    returncode: 1
+  transform:
+  - {}
+  - input:
+      cmdline:
+        replace: '/\{a/{a.b/'
+    output-expected:
+      stderr:
+        replace: '/\{a/{a.b/'
+  - input:
+      cmdline:
+        replace: '/\{a/{Text[a]/'
+    output-expected:
+      stderr:
+        replace: '/\{a/{Text[a]/'
+  - input:
+      cmdline:
+        replace: '/\{a/{text[A]/'
+    output-expected:
+      stderr:
+        replace: '/\{a/{text[A]/'
+
+- name: 'vrt-add-id: --format with idnum[elem] where no ids added to elem'
+  input:
+    cmdline: vrt-add-id --format="{idnum[text]}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: elem in format replacement field idnum[elem] must be the name of one of the elements to which ids are added: {idnum[text]}
+    returncode: 1
+
+- name: 'vrt-add-id: --format with substitution for int-valued field'
+  input:
+    cmdline: vrt-add-id --format="{id/x/y/}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: substitutions not allowed for integer-valued format replacement fields id and idnum[elem]: {id/x/y/}
+    returncode: 1
+  transform:
+  - {}
+  - &replace-id-idnum-sent
+    input:
+      cmdline: &repl-id-idnum-sent
+        replace:
+          str: '{id'
+          with: '{idnum[sentence]'
+    output-expected:
+      stderr: *repl-id-idnum-sent
+
+- name: 'vrt-add-id: --format with presentation "s" for int-valued field'
+  input:
+    cmdline: vrt-add-id --format="{id:8s}"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: invalid format specification for an integer-valued format replacement field: unknown format code 's' for object of type 'int': {id:8s}
+    returncode: 1
+  transform:
+  - {}
+  - *replace-id-idnum-sent
+  - *transf-no-optimize
+
+- name: 'vrt-add-id: --format with invalid format spec for int-valued field'
+  input:
+    # Incomplete cmdline, to be augmented in grouped transformations
+    cmdline: 'vrt-add-id --format="{id:'
+    stdin: *input-1
+  output:
+    stdout: ''
+    # Incomplete stderr, to be augmented in grouped transformations
+    stderr: 'vrt-add-id: error: invalid format specification for an integer-valued format replacement field: '
+    returncode: 1
+  transform:
+  # No {}: the values above should always be augmented
+  - input:
+      cmdline:
+        append: 'Z}"'
+    output-expected:
+      stderr:
+        append: |
+          unknown format code 'Z' for object of type 'int': {id:Z}
+  - input:
+      cmdline:
+        append: '.d}"'
+    output-expected:
+      stderr:
+        append: |
+          format specifier missing precision: {id:.d}
+
+- name: 'vrt-add-id: --format with invalid format spec for string field'
+  input:
+    # Incomplete cmdline, to be augmented in grouped transformations
+    cmdline: 'vrt-add-id --format="{sentence[a]:'
+    stdin: *input-1
+  output:
+    stdout: ''
+    # Incomplete stderr, to be augmented in grouped transformations
+    stderr: 'vrt-add-id: error: invalid format specification for a string-valued format replacement field: '
+    returncode: 1
+  transform:
+  # No {}: the values above should always be augmented
+  - input:
+      cmdline:
+        append: '8d}"'
+    output-expected:
+      stderr:
+        append: |
+          unknown format code 'd' for object of type 'str': {sentence[a]:8d}
+  - input:
+      cmdline:
+        append: 'Z}"'
+    output-expected:
+      stderr:
+        append: |
+          unknown format code 'Z' for object of type 'str': {sentence[a]:Z}
+  - input:
+      cmdline:
+        append: '-s}"'
+    output-expected:
+      stderr:
+        append: |
+          sign not allowed in string format specifier: {sentence[a]:-s}
+  - input:
+      cmdline:
+        append: ',s}"'
+    output-expected:
+      stderr:
+        append: |
+          cannot specify ',' with 's': {sentence[a]:,s}
+
+- name: 'vrt-add-id: --format referring to non-existent element or attribute'
+  input:
+    cmdline: vrt-add-id --format="{paragraph[z]}"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+    stderr: |
+      vrt-add-id: format replacement field {paragraph[z]}: key 'paragraph' not found
+      vrt-add-id: non-zero status 1
+    returncode: 1
+  transform:
+  - {}
+  # {text[z]}
+  - input:
+      cmdline:
+        replace: '/paragraph/text/'
+    output-expected:
+      stderr:
+        replace:
+        - '/\{paragraph/{text/'
+        - "/'paragraph/b'z"
 
 
 # Multiple different elements

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1979,6 +1979,108 @@
     input: *cmdline-verbose
   - *transf-verbose-noopt-prepend
 
+- name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different format specs'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:05x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-0b92f-f4dc">
+      <sentence a="a" id="s-b92f+f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-0b92f-f4cb">
+      <sentence a="b" id="s-b92f+f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-0294c-16a6">
+      <sentence a="c" id="s-294c+16a6-1f16">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - *transf-noopt-t2p3s3
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of different format specifications for idnum[text]: 04x, 05x
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+
+- name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different format specs (one with empty)'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-47407-f4dc">
+      <sentence a="a" id="s-b92f+f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-47407-f4cb">
+      <sentence a="b" id="s-b92f+f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-10572-16a6">
+      <sentence a="c" id="s-294c+16a6-1f16">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - *transf-noopt-t2p3s3
+  - name: --verbose
+    input: *cmdline-verbose
+    output-expected:
+      stderr: |
+        vrt-add-id: using the slower method because of different format specifications for idnum[text]: 04x, d (empty)
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+
+- name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different but equal format specs (with and without "d")'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:05d}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:05}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:05}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-47407">
+      <paragraph p="p1" id="p-47407-f4dc">
+      <sentence a="a" id="s-47407+f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-47407-f4cb">
+      <sentence a="b" id="s-47407+f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-10572">
+      <paragraph p="p3" id="p-10572-16a6">
+      <sentence a="c" id="s-10572+16a6-1f16">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
 
 # --verbose (and optimization)
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -908,3 +908,146 @@
       </sentence>
       </paragraph>
       </text>
+
+
+# --rename
+
+- name: 'vrt-add-id: --rename, no existing attribute'
+  input:
+    cmdline: vrt-add-id --id=x --rename
+    stdin: &input-multiattr |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_1="a" n_2="b">
+      <sentence a="a" id="1">
+      a
+      </sentence>
+      <sentence a="b" id="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_1="b" n_2="c">
+      <sentence a="c" id="3">
+      c
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_1="a" n_2="b">
+      <sentence a="a" id="1" x="1">
+      a
+      </sentence>
+      <sentence a="b" id="2" x="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_1="b" n_2="c">
+      <sentence a="c" id="3" x="3">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: --rename without argument, existing attribute'
+  input:
+    cmdline: vrt-add-id --id=a --rename
+    stdin: *input-multiattr
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_1="a" n_2="b">
+      <sentence id="1" a_orig="a" a="1">
+      a
+      </sentence>
+      <sentence id="2" a_orig="b" a="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_1="b" n_2="c">
+      <sentence id="3" a_orig="c" a="3">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: --rename fixed name, existing attribute'
+  input:
+    cmdline: vrt-add-id --id=a --rename=b
+    stdin: *input-multiattr
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_1="a" n_2="b">
+      <sentence id="1" b="a" a="1">
+      a
+      </sentence>
+      <sentence id="2" b="b" a="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_1="b" n_2="c">
+      <sentence id="3" b="c" a="3">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: --rename with {}, text and sentence, existing attributes'
+  input:
+    cmdline: vrt-add-id --rename="{}_" --element=text --id=n_1 --element=sentence --id=a
+    stdin: *input-multiattr
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_2="b" n_1_="a" n_1="1">
+      <sentence id="1" a_="a" a="1">
+      a
+      </sentence>
+      <sentence id="2" a_="b" a="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_2="c" n_1_="b" n_1="2">
+      <sentence id="3" a_="c" a="3">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: text and sentence, different renames, existing attributes'
+  input:
+    cmdline: vrt-add-id --element=text --id=n_1 --rename="{}_" --element=sentence --id=a --rename="{}a"
+    stdin: *input-multiattr
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="a" n="1" n_2="b" n_1_="a" n_1="1">
+      <sentence id="1" aa="a" a="1">
+      a
+      </sentence>
+      <sentence id="2" aa="b" a="2">
+      b
+      </sentence>
+      </text>
+      <text a="a" n="2" n_2="c" n_1_="b" n_1="2">
+      <sentence id="3" aa="c" a="3">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
+  input:
+    cmdline: vrt-add-id --element=text --id=a --rename=n --element=sentence --id=a --rename=id
+    stdin: *input-multiattr
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" n_1="a" n_2="b" n_3="a" a="1">
+      <sentence id="1" id_1="a" a="1">
+      a
+      </sentence>
+      <sentence id="2" id_1="b" a="2">
+      b
+      </sentence>
+      </text>
+      <text n="2" n_1="b" n_2="c" n_3="a" a="2">
+      <sentence id="3" id_1="c" a="3">
+      c
+      </sentence>
+      </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1051,3 +1051,33 @@
       c
       </sentence>
       </text>
+
+
+# Subtitutions in formats
+
+- name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids, with substitutions'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --seed=1 --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b1fd">
+      <paragraph p="p1" id="p-b1fd-b667">
+      <sentence a="a" id="s-b1fd+b667-7b6f">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-b1fd-027d">
+      <sentence a="b" id="s-b1fd+027d-50dc">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-391f">
+      <paragraph p="p3" id="p-391f-bb1d">
+      <sentence a="c" id="s-391f+bb1d-275c">
+      c
+      </sentence>
+      </paragraph>
+      </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -495,11 +495,11 @@
   transform: *transform-fast-s3
 
 
-# --type=random --end
+# --type=random --max
 
-- name: 'vrt-add-id: --type=random --end=3'
+- name: 'vrt-add-id: --type=random --max=3'
   input:
-    cmdline: vrt-add-id --type=random --end=3 --seed=2
+    cmdline: vrt-add-id --type=random --max=3 --seed=2
     stdin: *input-1
   output:
     stdout: |
@@ -519,9 +519,9 @@
       </text>
   transform: *transform-fast-s3
 
-- name: 'vrt-add-id: --type=random --end=20 (decimal, values of 2 hex digits)'
+- name: 'vrt-add-id: --type=random --max=20 (decimal, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --end=20 --seed=1
+    cmdline: vrt-add-id --type=random --max=20 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -541,9 +541,9 @@
       </text>
   transform: *transform-fast-s3
 
-- name: 'vrt-add-id: --type=random --end=0x1000 (hex, values of 3 hex digits)'
+- name: 'vrt-add-id: --type=random --max=0x1000 (hex, values of 3 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --end=0x1000 --seed=1
+    cmdline: vrt-add-id --type=random --max=0x1000 --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -563,9 +563,9 @@
       </text>
   transform: *transform-fast-s3
 
-- name: 'vrt-add-id: --type=random --end=2^8 (power, values of 2 hex digits)'
+- name: 'vrt-add-id: --type=random --max=2^8 (power, values of 2 hex digits)'
   input:
-    cmdline: vrt-add-id --type=random --end=2^8 --seed=1
+    cmdline: vrt-add-id --type=random --max=2^8 --seed=1
     stdin: *input-1
   output:
     stdout: &stdout-random-256-seed-1 |
@@ -585,9 +585,9 @@
       </text>
   transform: *transform-fast-s3
 
-- name: 'vrt-add-id: --type=random --end=2 (too small value)'
+- name: 'vrt-add-id: --type=random --max=2 (too small value)'
   input:
-    cmdline: vrt-add-id --type=random --end=2 --seed=2
+    cmdline: vrt-add-id --type=random --max=2 --seed=2
     stdin: *input-1
   output:
     stdout: |
@@ -602,7 +602,7 @@
       </text>
       <text n="2">
     stderr: |
-      vrt-add-id: more than 2 elements encountered; please increase --end
+      vrt-add-id: more than 2 elements encountered; please increase --max
       vrt-add-id: non-zero status 1
     returncode: 1
   transform:
@@ -622,7 +622,7 @@
 
 - name: 'vrt-add-id: --type=random, default seed for multiple element types'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --end=0x100 --element=text --element=sentence
+    cmdline: vrt-add-id --type=random --seed=1 --max=0x100 --element=text --element=sentence
     stdin: *input-1
   output:
     stdout: |
@@ -680,7 +680,7 @@
 
 - name: 'vrt-add-id: --type=random, explicitly same for multiple element types'
   input:
-    cmdline: vrt-add-id --type=random --end=0x100 --element=text --seed=1 --element=sentence --seed=1
+    cmdline: vrt-add-id --type=random --max=0x100 --element=text --seed=1 --element=sentence --seed=1
     stdin: *input-1
   output:
     stdout: |
@@ -705,7 +705,7 @@
 
 - name: 'vrt-add-id: --type=random, seed from file'
   input:
-    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
     stdin: *input-1
     file:seed.txt: '1'
   output:
@@ -729,7 +729,7 @@
 
 - name: 'vrt-add-id: --type=random, seed from 1 MiB file'
   input:
-    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
     stdin: *input-1
     file:seed.txt:
       value: ''
@@ -775,7 +775,7 @@
 
 - name: 'vrt-add-id: --type=random, non-existent seed file'
   input:
-    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    cmdline: vrt-add-id --type=random --max=2^8 --seed="<seed.txt"
     stdin: *input-1
   output:
     stdout: ''
@@ -876,7 +876,7 @@
 
 - name: 'vrt-add-id: --type=random --format'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --end=10 --format="*{id:03d}*"
+    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*"
     stdin: *input-1
   output:
     stdout: |
@@ -898,7 +898,7 @@
 
 - name: 'vrt-add-id: --type=random --format --prefix'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --end=10 --format="*{id:03d}*" --prefix="x-"
+    cmdline: vrt-add-id --type=random --seed=1 --max=10 --format="*{id:03d}*" --prefix="x-"
     stdin: *input-1
   output:
     stdout: |
@@ -920,7 +920,7 @@
 
 - name: 'vrt-add-id: --type=random --format; double {id}'
   input:
-    cmdline: vrt-add-id --type=random --seed=1 --end=100 --format="*{id:03d}-{id:02x}*"
+    cmdline: vrt-add-id --type=random --seed=1 --max=100 --format="*{id:03d}-{id:02x}*"
     stdin: *input-1
   output:
     stdout: |
@@ -1155,7 +1155,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
   input:
-    cmdline: vrt-add-id --id=xid --type=random --seed=0 --end=2^16 --format="{this[x]}-{id:04x}" --element=text --element=paragraph --element=sentence
+    cmdline: vrt-add-id --id=xid --type=random --seed=0 --max=2^16 --format="{this[x]}-{id:04x}" --element=text --element=paragraph --element=sentence
     stdin: |
       <!-- #vrt positional-attributes: word -->
       <text x="1">
@@ -1436,7 +1436,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with completely different options'
   input:
-    cmdline: vrt-add-id --element=text --type=counter --start=0 --id=tid --element=paragraph --type=counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --type=random --id=sid --seed=0 --end=2^16 --format="{id:04x}"
+    cmdline: vrt-add-id --element=text --type=counter --start=0 --id=tid --element=paragraph --type=counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --type=random --id=sid --seed=0 --max=2^16 --format="{id:04x}"
     stdin: *input-para
   output:
     stdout: |
@@ -1480,7 +1480,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
-    cmdline: vrt-add-id --id=xid --type=random --seed=0 --end=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
+    cmdline: vrt-add-id --id=xid --type=random --seed=0 --max=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
     stdin: *input-para
   output:
     stdout: |
@@ -1565,7 +1565,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with some common options'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
     stdin: *input-para
   output:
     stdout: &output-para-1 |
@@ -1593,7 +1593,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="{text[id]}-p-{id:04x}" --seed=1 --element=sentence --format="{paragraph[id]}-s-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="{text[id]}-p-{id:04x}" --seed=1 --element=sentence --format="{paragraph[id]}-s-{id:04x}" --seed=2
     stdin: *input-para
   output:
     stdout: |
@@ -1762,7 +1762,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids, with substitutions'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --seed=1 --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --seed=1 --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}" --seed=2
     stdin: *input-para
   output:
     stdout: &output-para-subst |
@@ -1802,7 +1802,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to idnum[elem]'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
     stdin: *input-para
   output:
     # This is another way to achieve the same result as with the
@@ -1812,7 +1812,7 @@
 
 - name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph but previous paragraphs'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
     stdin:
       value: *input-para
       transform:
@@ -1858,7 +1858,7 @@
 
 - name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph without previous paragraphs'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
     stdin:
       value: *input-para
       transform:
@@ -1888,7 +1888,7 @@
 
 - name: 'vrt-add-id: --verbose; text, paragraph, sentence with some common options'
   input:
-    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2 --verbose
+    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2 --verbose
     stdin: *input-para
   output:
     stdout: *output-para-1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -701,6 +701,77 @@
       </text>
 
 
+# Format with "{this[attr]}"
+
+- name: 'vrt-add-id: --format with {this[attr]}'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{this[a]}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="a-001">
+      a
+      </sentence>
+      <sentence a="b" id="b-002">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="c-003">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
+  input:
+    cmdline: vrt-add-id --id=xid --type=random --seed=0 --end=2^16 --format="{this[x]}-{id:04x}" --element=text --element=paragraph --element=sentence
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text x="1">
+      <paragraph x="p1">
+      <sentence x="a">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph x="p2">
+      <sentence x="b">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text x="2">
+      <paragraph x="p3">
+      <sentence x="c">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text x="1" xid="1-b1fd">
+      <paragraph x="p1" xid="p1-b1fd">
+      <sentence x="a" xid="a-b1fd">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph x="p2" xid="p2-391f">
+      <sentence x="b" xid="b-391f">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text x="2" xid="2-391f">
+      <paragraph x="p3" xid="p3-3d2b">
+      <sentence x="c" xid="c-3d2b">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+
 # Multiple different elements
 
 - name: 'vrt-add-id: text, paragraph, sentence with completely different options'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -652,3 +652,50 @@
       c
       </sentence>
       </text>
+
+- name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
+  input:
+    cmdline: vrt-add-id --counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}"
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph p="p1">
+      <sentence a="a">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2">
+      <sentence a="b">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph p="p3">
+      <sentence a="c">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph p="p1">
+      <sentence a="a" id="01-p1-a-001">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2">
+      <sentence a="b" id="01-p2-b-002">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph p="p3">
+      <sentence a="c" id="02-p3-c-003">
+      c
+      </sentence>
+      </paragraph>
+      </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -53,11 +53,13 @@
   - {}
   # Test that the command with --no-optimize produces the same result
   - &transf-no-optimize
+    name: --no-optimize
     input: &cmdline-no-optimize
       cmdline:
         append: ' --no-optimize'
   # Test the command with --verbose
   - &transf-verbose-fast-s3
+    name: --verbose
     input: &cmdline-verbose
       cmdline:
         append: ' --verbose'
@@ -67,6 +69,7 @@
         vrt-add-id: added 3 sentence ids
   # Test the command with --verbose --no-optimize
   - &transf-verbose-noopt-s3
+    name: --verbose --no-optimize
     input: &cmdline-verbose-no-optimize
       cmdline:
         append: ' --verbose --no-optimize'
@@ -100,12 +103,14 @@
   - {}
   - *transf-no-optimize
   - &transf-verbose-fast-t2
+    name: --verbose
     input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the faster method
         vrt-add-id: added 2 text ids
   - &transf-verbose-noopt-t2
+    name: --verbose --no-optimize
     input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
@@ -122,12 +127,14 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of not finding elements x
         vrt-add-id: added 0 x ids
-  - input: *cmdline-verbose-no-optimize
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --no-optimize
@@ -226,7 +233,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --sort
@@ -249,8 +257,10 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
   - &transf-verbose-noopt-prepend
+    name: --verbose --no-optimize
     input: *cmdline-verbose-no-optimize
     output-expected:
       stderr:
@@ -281,7 +291,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --force
@@ -313,6 +324,7 @@
   - {}
   - *transf-no-optimize
   - &transf-verbose-force-t2
+    name: --verbose
     input: *cmdline-verbose
     output-expected:
       stderr: |
@@ -569,6 +581,7 @@
   - {}
   - *transf-no-optimize
   - &transf-verbose-fast-prepend
+    name: --verbose
     input: *cmdline-verbose
     output-expected:
       stderr:
@@ -602,12 +615,14 @@
   transform: &transform-fast-t2s3-seed
   - {}
   # Default --seed, same value explicitly for sentence
-  - input:
+  - name: default --seed, explicitly same value for sentence
+    input:
       cmdline:
         append: ' --seed=1'
   - *transf-no-optimize
   # Test the command with --verbose
   - &transf-verbose-fast-t2s3
+    name: --verbose
     input: *cmdline-verbose
     output-expected:
       stderr: |
@@ -615,18 +630,21 @@
         vrt-add-id: added 2 text ids, 3 sentence ids
   # Test the command with --verbose --no-optimize
   - &transf-verbose-noopt-t2s3
+    name: --verbose --no-optimize
     input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --no-optimize
         vrt-add-id: added 2 text ids, 3 sentence ids
   # Read seed from file
-  - input:
+  - name: seed from file
+    input:
       cmdline:
         replace: '/seed=1/seed="<seed.txt"/'
       file:seed.txt: '1'
   # Read seed from file, explicitly the same seed for sentence
-  - input:
+  - name: seed from file, explicitly same seed for sentence
+    input:
       cmdline:
       - replace: '/seed=1/seed="<seed.txt"/'
       - append: ' --seed="<seed.txt"'
@@ -671,11 +689,13 @@
   - *transf-verbose-noopt-s3
   # Test that the seed read from file produces the same result as the
   # same seed literally
-  - input:
+  - name: seed from file same as literal seed
+    input:
       cmdline:
         replace: '/<seed\.txt/1/'
   # Test that spaces around the file name are stripped
-  - input:
+  - name: spaces around file name stripped
+    input:
       cmdline:
         replace: '/<seed.txt/< \tseed.txt \t/'
 
@@ -710,11 +730,13 @@
   - *transf-verbose-noopt-s3
   # The seed file with something appended should produce the same
   # result, as only the first 1 MiB of the seed file is used
-  - input:
+  - name: append to 1 MiB seed
+    input:
       file:seed.txt:
         append: 'foobar'
   # A one byte shorter seed file should produce different ids
-  - input:
+  - name: truncate 1 MiB seed
+    input:
       file:seed.txt:
         python: return value[:-1]
     output-expected:
@@ -891,7 +913,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of using {id} with different format specifications: 03d, 02x
@@ -1003,7 +1026,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {sentence[a]}
@@ -1059,7 +1083,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[n]:0>2s}
@@ -1092,7 +1117,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[a]}
@@ -1148,12 +1174,14 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[x]}
         vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
-  - input: *cmdline-verbose-no-optimize
+  - name: --verbose --no-optimize
+    input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --no-optimize
@@ -1173,19 +1201,22 @@
     returncode: 1
   transform:
   - {}
-  - input:
+  - name: attribute access
+    input:
       cmdline:
         replace: '/\{a/{a.b/'
     output-expected:
       stderr:
         replace: '/\{a/{a.b/'
-  - input:
+  - name: capitalized element name
+    input:
       cmdline:
         replace: '/\{a/{Text[a]/'
     output-expected:
       stderr:
         replace: '/\{a/{Text[a]/'
-  - input:
+  - name: capitalized attribute name
+    input:
       cmdline:
         replace: '/\{a/{text[A]/'
     output-expected:
@@ -1216,6 +1247,7 @@
   transform:
   - {}
   - &replace-id-idnum-sent
+    name: 'idnum[sentence]'
     input:
       cmdline: &repl-id-idnum-sent
         replace:
@@ -1251,14 +1283,16 @@
     returncode: 1
   transform:
   # No {}: the values above should always be augmented
-  - input:
+  - name: format code "Z"
+    input:
       cmdline:
         append: 'Z}"'
     output-expected:
       stderr:
         append: |
           unknown format code 'Z' for object of type 'int': {id:Z}
-  - input:
+  - name: format spec ".d"
+    input:
       cmdline:
         append: '.d}"'
     output-expected:
@@ -1278,28 +1312,32 @@
     returncode: 1
   transform:
   # No {}: the values above should always be augmented
-  - input:
+  - name: format spec "8d"
+    input:
       cmdline:
         append: '8d}"'
     output-expected:
       stderr:
         append: |
           unknown format code 'd' for object of type 'str': {sentence[a]:8d}
-  - input:
+  - name: format spec "Z"
+    input:
       cmdline:
         append: 'Z}"'
     output-expected:
       stderr:
         append: |
           unknown format code 'Z' for object of type 'str': {sentence[a]:Z}
-  - input:
+  - name: format spec "-s"
+    input:
       cmdline:
         append: '-s}"'
     output-expected:
       stderr:
         append: |
           sign not allowed in string format specifier: {sentence[a]:-s}
-  - input:
+  - name: format spec ",s"
+    input:
       cmdline:
         append: ',s}"'
     output-expected:
@@ -1322,7 +1360,8 @@
   transform:
   - {}
   # {text[z]}
-  - input:
+  - name: 'text[z]'
+    input:
       cmdline:
         replace: '/paragraph/text/'
     output-expected:
@@ -1365,12 +1404,14 @@
   - {}
   - *transf-no-optimize
   - &transf-fast-t2p3s3
+    name: --verbose
     input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the faster method
         vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   - &transf-noopt-t2p3s3
+    name: --verbose --no-optimize
     input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
@@ -1490,7 +1531,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]}
@@ -1537,7 +1579,8 @@
   transform: &transform-rename-s3
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --rename
@@ -1633,12 +1676,14 @@
   transform: &transform-rename-t2s3
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --rename
         vrt-add-id: added 2 text ids, 3 sentence ids
   - &transf-noopt-t2s3
+    name: --verbose --no-optimize
     input: *cmdline-verbose-no-optimize
     output-expected:
       stderr: |
@@ -1699,7 +1744,8 @@
   transform:
   - {}
   - *transf-no-optimize
-  - input: *cmdline-verbose
+  - name: --verbose
+    input: *cmdline-verbose
     output-expected:
       stderr: |
         vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]/t-//}
@@ -1736,7 +1782,8 @@
       vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   transform:
   - {}
-  - input: *cmdline-no-optimize
+  - name: --no-optimize
+    input: *cmdline-no-optimize
     output-expected:
       stderr:
         replace: '/faster method/slower method because of --no-optimize/'
@@ -1752,43 +1799,52 @@
       vrt-add-id: added 3 sentence ids
   transform:
   - {}
-  - input:
+  - name: format spec "x"
+    input:
       cmdline:
       - replace: '/:d/:x/'
-  - input:
+  - name: format spec "1"
+    input:
       cmdline:
       - replace: '/:d/:1/'
-  - input:
+  - name: format spec "X"
+    input:
       cmdline:
       - replace: '/:d/:X/'
-  - input:
+  - name: empty format spec
+    input:
       cmdline:
       - replace: '/:d/:/'
-  - input:
+  - name: format spec "2d"
+    input:
       cmdline:
       - replace: '/:d/:2d/'
     output-expected:
       stdout:
       - replace: '/id="/id=" /'
-  - input:
+  - name: format spec "2"
+    input:
       cmdline:
       - replace: '/:d/:2/'
     output-expected:
       stdout:
       - replace: '/id="/id=" /'
-  - input:
+  - name: format spec "2x"
+    input:
       cmdline:
       - replace: '/:d/:2x/'
     output-expected:
       stdout:
       - replace: '/id="/id=" /'
-  - input:
+  - name: format spec "03x"
+    input:
       cmdline:
       - replace: '/:d/:03x/'
     output-expected:
       stdout:
       - replace: '/id="/id="00/'
-  - input: *cmdline-no-optimize
+  - name: --no-optimize
+    input: *cmdline-no-optimize
     output-expected:
       stderr:
         replace: '/faster method/slower method because of --no-optimize/'
@@ -1804,7 +1860,8 @@
       vrt-add-id: added 3 sentence ids
   transform:
   - {}
-  - input:
+  - name: format spec "<5d"
+    input:
       cmdline:
         replace: '/<1/<5/'
     output-expected:
@@ -1812,7 +1869,8 @@
         replace: '/(id=".)/\1    /'
       stderr:
         replace: '/<1/<5/'
-  - input:
+  - name: format spec ">5d"
+    input:
       cmdline:
         replace: '/<1/>5/'
     output-expected:
@@ -1820,7 +1878,8 @@
         replace: '/id="(.)/id="    \1/'
       stderr:
         replace: '/<1/>5/'
-  - input:
+  - name: format spec "^5d"
+    input:
       cmdline:
         replace: '/<1/^5/'
     output-expected:
@@ -1828,7 +1887,8 @@
         replace: '/id="(.)/id="  \1  /'
       stderr:
         replace: '/<1/^5/'
-  - input:
+  - name: format spec "-^5d"
+    input:
       cmdline:
         replace: '/<1/-^5/'
     output-expected:
@@ -1836,7 +1896,8 @@
         replace: '/id="(.)/id="--\1--/'
       stderr:
         replace: '/<1/-^5/'
-  - input:
+  - name: format spec "#04x"
+    input:
       cmdline:
         replace: '/<1d/#04x/'
     output-expected:
@@ -1844,7 +1905,8 @@
         replace: '/id="(.)/id="0x0\1/'
       stderr:
         replace: '/<1d/#04x/'
-  - input: *cmdline-no-optimize
+  - name: --no-optimize
+    input: *cmdline-no-optimize
     output-expected:
       stderr:
         replace: '/format specification.*/--no-optimize/'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -2040,34 +2040,25 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-47407-f4dc">
+      <paragraph p="p1" id="p-b92f-f4dc">
       <sentence a="a" id="s-b92f+f4dc-a6de">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-47407-f4cb">
+      <paragraph p="p2" id="p-b92f-f4cb">
       <sentence a="b" id="s-b92f+f4cb-7475">
       b
       </sentence>
       </paragraph>
       </text>
       <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-10572-16a6">
+      <paragraph p="p3" id="p-294c-16a6">
       <sentence a="c" id="s-294c+16a6-1f16">
       c
       </sentence>
       </paragraph>
       </text>
-  transform:
-  - {}
-  - *transf-no-optimize
-  - *transf-noopt-t2p3s3
-  - name: --verbose
-    input: *cmdline-verbose
-    output-expected:
-      stderr: |
-        vrt-add-id: using the slower method because of different format specifications for idnum[text]: 04x, d (empty)
-        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+  transform: *transform-fast-t2p3s3
 
 - name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different but equal format specs (with and without "d")'
   input:
@@ -2091,6 +2082,68 @@
       <text n="2" id="t-10572">
       <paragraph p="p3" id="p-10572-16a6">
       <sentence a="c" id="s-10572+16a6-1f16">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: text, paragraph, sentence; id and idnum[elem] without format spec (using default)'
+  input:
+    cmdline:
+    - vrt-add-id --id=id --type=random --max=2^16 --format="{id}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}" --seed=2
+    # With idnum[elem] for the current element
+    - vrt-add-id --id=id --type=random --max=2^16 --format="{idnum[text]}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-b92f-f4dc">
+      <sentence a="a" id="s-b92f+f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-b92f-f4cb">
+      <sentence a="b" id="s-b92f+f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-294c-16a6">
+      <sentence a="c" id="s-294c+16a6-1f16">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+  transform: *transform-fast-t2p3s3
+
+- name: 'vrt-add-id: text, paragraph, sentence; id with non-default format spec, referred to from another element format (without format spec, using the same)'
+  input:
+    cmdline:
+    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="t-{id}" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id:06x}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}" --seed=2
+    # With idnum[elem] for the current element
+    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="t-{idnum[text]}" --seed=0 --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]:06x}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-b92f-00f4dc">
+      <sentence a="a" id="s-b92f+00f4dc-a6de">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-b92f-00f4cb">
+      <sentence a="b" id="s-b92f+00f4cb-7475">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-294c-0016a6">
+      <sentence a="c" id="s-294c+0016a6-1f16">
       c
       </sentence>
       </paragraph>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -62,20 +62,18 @@
       cmdline:
         append: ' --verbose'
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the faster method
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 3 sentence ids
   # Test the command with --verbose --no-optimize
   - &transf-verbose-noopt-s3
     input: &cmdline-verbose-no-optimize
       cmdline:
         append: ' --verbose --no-optimize'
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 3 sentence ids
 
 
 - name: 'vrt-add-id: --element=text'
@@ -104,17 +102,15 @@
   - &transf-verbose-fast-t2
     input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the faster method
-          vrt-add-id: added 2 text ids
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids
   - &transf-verbose-noopt-t2
     input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 2 text ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids
 
 
 - name: 'vrt-add-id: Non-existent element (no change)'
@@ -128,16 +124,14 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of not finding elements x
-          vrt-add-id: added 0 x ids
+      stderr: |
+        vrt-add-id: using the slower method because of not finding elements x
+        vrt-add-id: added 0 x ids
   - input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 0 x ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 0 x ids
 
 
 - name: 'vrt-add-id: --id'
@@ -234,10 +228,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --sort
-          vrt-add-id: added 2 text ids
+      stderr: |
+        vrt-add-id: using the slower method because of --sort
+        vrt-add-id: added 2 text ids
   - *transf-verbose-noopt-t2
 
 
@@ -290,10 +283,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --force
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --force
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 
@@ -323,10 +315,9 @@
   - &transf-verbose-force-t2
     input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --force
-          vrt-add-id: added 2 text ids
+      stderr: |
+        vrt-add-id: using the slower method because of --force
+        vrt-add-id: added 2 text ids
   - *transf-verbose-noopt-t2
 
 
@@ -619,31 +610,27 @@
   - &transf-verbose-fast-t2s3
     input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the faster method
-          vrt-add-id: added 2 text ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids, 3 sentence ids
   # Test the command with --verbose --no-optimize
   - &transf-verbose-noopt-t2s3
     input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 2 text ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 sentence ids
   # Read seed from file
   - input:
       cmdline:
         replace: '/seed=1/seed="<seed.txt"/'
-      file:seed.txt:
-        set-value: '1'
+      file:seed.txt: '1'
   # Read seed from file, explicitly the same seed for sentence
   - input:
       cmdline:
       - replace: '/seed=1/seed="<seed.txt"/'
       - append: ' --seed="<seed.txt"'
-      file:seed.txt:
-        set-value: '1'
+      file:seed.txt: '1'
 
 - name: 'vrt-add-id: --type=random, explicitly same for multiple element types'
   input:
@@ -906,10 +893,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of using {id} with different format specifications: 03d, 02x
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of using {id} with different format specifications: 03d, 02x
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 
@@ -1019,10 +1005,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {sentence[a]}
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {sentence[a]}
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
@@ -1076,10 +1061,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[n]:0>2s}
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[n]:0>2s}
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 
@@ -1110,10 +1094,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[a]}
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[a]}
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
@@ -1167,16 +1150,14 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[x]}
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {this[x]}
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   - input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
 
 
 # Invalid --format
@@ -1386,17 +1367,15 @@
   - &transf-fast-t2p3s3
     input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the faster method
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the faster method
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   - &transf-noopt-t2p3s3
     input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
@@ -1513,10 +1492,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]}
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]}
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   - *transf-noopt-t2p3s3
 
 
@@ -1561,10 +1539,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --rename
-          vrt-add-id: added 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --rename
+        vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
 - name: 'vrt-add-id: --rename without argument, existing attribute'
@@ -1658,17 +1635,15 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --rename
-          vrt-add-id: added 2 text ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --rename
+        vrt-add-id: added 2 text ids, 3 sentence ids
   - &transf-noopt-t2s3
     input: *cmdline-verbose-no-optimize
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --no-optimize
-          vrt-add-id: added 2 text ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --no-optimize
+        vrt-add-id: added 2 text ids, 3 sentence ids
 
 - name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
   input:
@@ -1726,10 +1701,9 @@
   - *transf-no-optimize
   - input: *cmdline-verbose
     output-expected:
-      stderr:
-        set-value: |
-          vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]/t-//}
-          vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
+      stderr: |
+        vrt-add-id: using the slower method because of --format replacement field other than {id} or {idnum[elem]}: {text[id]/t-//}
+        vrt-add-id: added 2 text ids, 3 paragraph ids, 3 sentence ids
   - *transf-noopt-t2p3s3
 
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1914,7 +1914,10 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to idnum[elem]'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline:
+    - vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    # Same with {idnum[elem]} everywhere instead of {id}
+    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="{idnum[text]:04x}" --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{idnum[paragraph]:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{idnum[sentence]:04x}" --seed=2
     stdin: *input-para
   output:
     # This is another way to achieve the same result as with the

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -564,3 +564,67 @@
       c
       </sentence>
       </text>
+
+
+# --hash
+
+- name: 'vrt-add-id: --hash; format with {hash}'
+  input:
+    cmdline: vrt-add-id --counter --hash=abc --format="{hash}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: &output-hash |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="a9993e364706816aba3e25717850c26c9cd0d89d-001">
+      a
+      </sentence>
+      <sentence a="b" id="a9993e364706816aba3e25717850c26c9cd0d89d-002">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="a9993e364706816aba3e25717850c26c9cd0d89d-003">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: --hash; format with {hash1}'
+  input:
+    cmdline: vrt-add-id --counter --hash=abc --format="{hash1}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: *output-hash
+
+- name: 'vrt-add-id: Multiple --hash'
+  input:
+    cmdline: vrt-add-id --counter --hash=abc --hash=def --hash=ghi --format="{hash1:.4}-{hash2:.4}-{hash3:.6}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="a999-589c-481743-001">
+      a
+      </sentence>
+      <sentence a="b" id="a999-589c-481743-002">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="a999-589c-481743-003">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-add-id: Format refers to non-existent {hashN}'
+  input:
+    cmdline: vrt-add-id --counter --hash=abc --format="{hash1:.4}-{hash2:.4}-{id:03d}"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+    stderr:
+      contains: "KeyError: 'hash2'"
+    returncode: 1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -240,6 +240,10 @@
         vrt-add-id: using the slower method because of --sort
         vrt-add-id: added 2 text ids
   - *transf-verbose-noopt-t2
+  - name: -e
+    input:
+      cmdline:
+        replace: '/--element/-e/'
 
 
 - name: 'vrt-add-id: Existing id attribute (without --force)'
@@ -343,7 +347,7 @@
     stdout: ''
     stderr:
       - regex: '^usage'
-      - regex: "vrt-add-id: error: argument --element: not a field name: b'-x'"
+      - regex: "vrt-add-id: error: argument --element/-e: not a field name: b'-x'"
     returncode: 2
 
 - name: 'vrt-add-id: Invalid attribute name'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1511,6 +1511,19 @@
   - {}
   - *transf-no-optimize
 
+- name: 'vrt-add-id: --format without replacement fields'
+  input:
+    cmdline: vrt-add-id --seed=1 --element=text --format="{id:08x}" --element=sentence --format="xxx"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: format string for element "sentence" must contain replacement field "id" or "idnum[sentence]": xxx
+    returncode: 1
+  transform:
+  - {}
+  - *transf-no-optimize
+
 - name: 'vrt-add-id: --format referring to idnum of a specified element that is not in input'
   input:
     cmdline: vrt-add-id --seed=1 --element=text --format="{id:08x}" --element=sentence --format="{idnum[text]}-{id:08x}"

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -486,15 +486,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="e91f0e05">
+      <sentence a="a" id="7a6e75f5">
       a
       </sentence>
-      <sentence a="b" id="5ea89fed">
+      <sentence a="b" id="1df61006">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="0ab0a68c">
+      <sentence a="c" id="db4ffcbb">
       c
       </sentence>
       </text>
@@ -511,10 +511,10 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="1">
+      <sentence a="a" id="2">
       a
       </sentence>
-      <sentence a="b" id="2">
+      <sentence a="b" id="1">
       b
       </sentence>
       </text>
@@ -533,15 +533,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="05">
+      <sentence a="a" id="0f">
       a
       </sentence>
-      <sentence a="b" id="0b">
+      <sentence a="b" id="01">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="08">
+      <sentence a="c" id="03">
       c
       </sentence>
       </text>
@@ -555,15 +555,15 @@
     stdout: &stdout-random-4096-seed-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="568">
+      <sentence a="a" id="f4d">
       a
       </sentence>
-      <sentence a="b" id="bd5">
+      <sentence a="b" id="f4c">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="8af">
+      <sentence a="c" id="16a">
       c
       </sentence>
       </text>
@@ -577,15 +577,15 @@
     stdout: &stdout-random-256-seed-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="56">
+      <sentence a="a" id="f4">
       a
       </sentence>
-      <sentence a="b" id="bd">
+      <sentence a="b" id="16">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="8a">
+      <sentence a="c" id="3b">
       c
       </sentence>
       </text>
@@ -676,15 +676,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="2768">
+      <sentence a="a" id="7835">
       a
       </sentence>
-      <sentence a="b" id="6058">
+      <sentence a="b" id="7833">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="4446">
+      <sentence a="c" id="0724">
       c
       </sentence>
       </text>
@@ -730,18 +730,20 @@
     cmdline: vrt-add-id --type=random --seed=1 --max=0x100 --element=text --element=sentence
     stdin: *input-1
   output:
+    # The ids of the first text and sentence are really the same: the
+    # random number generator produces two same values in a row
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="e9">
-      <sentence a="a" id="56">
+      <text n="1" id="f4">
+      <sentence a="a" id="f4">
       a
       </sentence>
-      <sentence a="b" id="bd">
+      <sentence a="b" id="16">
       b
       </sentence>
       </text>
-      <text n="2" id="24">
-      <sentence a="c" id="8a">
+      <text n="2" id="3b">
+      <sentence a="c" id="dd">
       c
       </sentence>
       </text>
@@ -783,28 +785,6 @@
       - append: ' --seed="<seed.txt"'
       file:seed.txt: '1'
 
-- name: 'vrt-add-id: --type=random, explicitly same for multiple element types'
-  input:
-    cmdline: vrt-add-id --type=random --max=0x100 --element=text --seed=1 --element=sentence --seed=1
-    stdin: *input-1
-  output:
-    stdout: |
-      <!-- #vrt positional-attributes: word -->
-      <text n="1" id="f4">
-      <sentence a="a" id="f4">
-      a
-      </sentence>
-      <sentence a="b" id="16">
-      b
-      </sentence>
-      </text>
-      <text n="2" id="16">
-      <sentence a="c" id="3b">
-      c
-      </sentence>
-      </text>
-  transform: *transform-fast-t2s3-seed
-
 
 # Random seed from file
 
@@ -844,15 +824,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="c7">
+      <sentence a="a" id="2e">
       a
       </sentence>
-      <sentence a="b" id="94">
+      <sentence a="b" id="c4">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="b6">
+      <sentence a="c" id="cd">
       c
       </sentence>
       </text>
@@ -874,9 +854,9 @@
         python: return value[:-1]
     output-expected:
       stdout:
-      - replace: '/c7/72/'
-      - replace: '/94/ba/'
-      - replace: '/b6/97/'
+      - replace: '/2e/25/'
+      - replace: '/c4/4e/'
+      - replace: '/cd/06/'
 
 - name: 'vrt-add-id: --type=random, non-existent seed file'
   input:
@@ -987,15 +967,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="*002*">
+      <sentence a="a" id="*007*">
       a
       </sentence>
-      <sentence a="b" id="*005*">
+      <sentence a="b" id="*000*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="*004*">
+      <sentence a="c" id="*001*">
       c
       </sentence>
       </text>
@@ -1009,15 +989,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="x-*002*">
+      <sentence a="a" id="x-*007*">
       a
       </sentence>
-      <sentence a="b" id="x-*005*">
+      <sentence a="b" id="x-*000*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="x-*004*">
+      <sentence a="c" id="x-*001*">
       c
       </sentence>
       </text>
@@ -1031,15 +1011,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="*021-15*">
+      <sentence a="a" id="*061-3d*">
       a
       </sentence>
-      <sentence a="b" id="*047-2f*">
+      <sentence a="b" id="*005-05*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="*034-22*">
+      <sentence a="c" id="*087-57*">
       c
       </sentence>
       </text>
@@ -1520,7 +1500,7 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options and {this[attr]}'
   input:
-    cmdline: vrt-add-id --id=xid --type=random --seed=0 --max=2^16 --format="{this[x]}-{id:04x}" --element=text --element=paragraph --element=sentence
+    cmdline: vrt-add-id --id=xid --type=random --seed=1 --max=2^16 --format="{this[x]}-{id:04x}" --element=text --element=paragraph --element=sentence
     stdin: |
       <!-- #vrt positional-attributes: word -->
       <text x="1">
@@ -1545,21 +1525,21 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text x="1" xid="1-9031">
-      <paragraph x="p1" xid="p1-678f">
-      <sentence x="a" xid="a-3277">
+      <text x="1" xid="1-f4dc">
+      <paragraph x="p1" xid="p1-f4cb">
+      <sentence x="a" xid="a-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph x="p2" xid="p2-2af3">
-      <sentence x="b" xid="b-960b">
+      <paragraph x="p2" xid="p2-3bec">
+      <sentence x="b" xid="b-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text x="2" xid="2-0e08">
-      <paragraph x="p3" xid="p3-a606">
-      <sentence x="c" xid="c-68c2">
+      <text x="2" xid="2-c2c0">
+      <paragraph x="p3" xid="p3-95da">
+      <sentence x="c" xid="c-0372">
       c
       </sentence>
       </paragraph>
@@ -1814,26 +1794,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with completely different options'
   input:
-    cmdline: vrt-add-id --element=text --type=counter --start=0 --id=tid --element=paragraph --type=counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --type=random --id=sid --seed=0 --max=2^16 --format="{id:04x}"
+    cmdline: vrt-add-id --seed=1 --element=text --type=counter --start=0 --id=tid --element=paragraph --type=counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --type=random --id=sid --max=2^16 --format="{id:04x}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1" tid="0">
       <paragraph p="p1" pid="p-0a">
-      <sentence a="a" sid="b92f">
+      <sentence a="a" sid="f4dc">
       a
       </sentence>
       </paragraph>
       <paragraph p="p2" pid="p-0b">
-      <sentence a="b" sid="294c">
+      <sentence a="b" sid="f4cb">
       b
       </sentence>
       </paragraph>
       </text>
       <text n="2" tid="1">
       <paragraph p="p3" pid="p-0c">
-      <sentence a="c" sid="8350">
+      <sentence a="c" sid="16a6">
       c
       </sentence>
       </paragraph>
@@ -1858,26 +1838,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with same options'
   input:
-    cmdline: vrt-add-id --id=xid --type=random --seed=0 --max=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
+    cmdline: vrt-add-id --id=xid --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" xid="9031">
-      <paragraph p="p1" xid="678f">
-      <sentence a="a" xid="3277">
+      <text n="1" xid="f4dc">
+      <paragraph p="p1" xid="f4cb">
+      <sentence a="a" xid="16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" xid="2af3">
-      <sentence a="b" xid="960b">
+      <paragraph p="p2" xid="3bec">
+      <sentence a="b" xid="ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" xid="0e08">
-      <paragraph p="p3" xid="a606">
-      <sentence a="c" xid="68c2">
+      <text n="2" xid="c2c0">
+      <paragraph p="p3" xid="95da">
+      <sentence a="c" xid="0372">
       c
       </sentence>
       </paragraph>
@@ -1943,26 +1923,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence with some common options'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --prefix="p-" --element=sentence --prefix="s-"
     stdin: *input-para
   output:
     stdout: &output-para-1 |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-f4dc">
-      <sentence a="a" id="s-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4cb">
+      <sentence a="a" id="s-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-f4cb">
-      <sentence a="b" id="s-7475">
+      <paragraph p="p2" id="p-3bec">
+      <sentence a="b" id="s-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-16a6">
-      <sentence a="c" id="s-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-95da">
+      <sentence a="c" id="s-0372">
       c
       </sentence>
       </paragraph>
@@ -1971,26 +1951,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="{text[id]}-p-{id:04x}" --seed=1 --element=sentence --format="{paragraph[id]}-s-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="{text[id]}-p-{id:04x}" --element=sentence --format="{paragraph[id]}-s-{id:04x}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="t-b92f-p-f4dc">
-      <sentence a="a" id="t-b92f-p-f4dc-s-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="t-f4dc-p-f4cb">
+      <sentence a="a" id="t-f4dc-p-f4cb-s-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="t-b92f-p-f4cb">
-      <sentence a="b" id="t-b92f-p-f4cb-s-7475">
+      <paragraph p="p2" id="t-f4dc-p-3bec">
+      <sentence a="b" id="t-f4dc-p-3bec-s-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="t-294c-p-16a6">
-      <sentence a="c" id="t-294c-p-16a6-s-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="t-c2c0-p-95da">
+      <sentence a="c" id="t-c2c0-p-95da-s-0372">
       c
       </sentence>
       </paragraph>
@@ -2140,26 +2120,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids, with substitutions'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --seed=1 --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}"
     stdin: *input-para
   output:
     stdout: &output-para-subst |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-b92f-f4dc">
-      <sentence a="a" id="s-b92f+f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4dc-f4cb">
+      <sentence a="a" id="s-f4dc+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b92f-f4cb">
-      <sentence a="b" id="s-b92f+f4cb-7475">
+      <paragraph p="p2" id="p-f4dc-3bec">
+      <sentence a="b" id="s-f4dc+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-294c-16a6">
-      <sentence a="c" id="s-294c+16a6-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-c2c0-95da">
+      <sentence a="c" id="s-c2c0+95da-0372">
       c
       </sentence>
       </paragraph>
@@ -2181,9 +2161,9 @@
 - name: 'vrt-add-id: text, paragraph, sentence; format referring to idnum[elem]'
   input:
     cmdline:
-    - vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}"
     # Same with {idnum[elem]} everywhere instead of {id}
-    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="{idnum[text]:04x}" --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{idnum[paragraph]:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{idnum[sentence]:04x}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --element=text --format="{idnum[text]:04x}" --prefix="t-" --element=paragraph --format="p-{idnum[text]:04x}-{idnum[paragraph]:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{idnum[sentence]:04x}"
     stdin: *input-para
   output:
     # This is another way to achieve the same result as with the
@@ -2193,7 +2173,7 @@
 
 - name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph but previous paragraphs'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}"
     stdin:
       value: *input-para
       transform:
@@ -2204,20 +2184,20 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-b92f-f4dc">
-      <sentence a="a" id="s-b92f+f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4dc-f4cb">
+      <sentence a="a" id="s-f4dc+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b92f-f4cb">
-      <sentence a="b" id="s-b92f+f4cb-7475">
+      <paragraph p="p2" id="p-f4dc-3bec">
+      <sentence a="b" id="s-f4dc+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <sentence a="c" id="s-294c+f4cb-1f16">
+      <text n="2" id="t-c2c0">
+      <sentence a="c" id="s-c2c0+3bec-95da">
       c
       </sentence>
       </text>
@@ -2239,7 +2219,7 @@
 
 - name: 'vrt-add-id: --format with {idnum[elem]}, missing paragraph without previous paragraphs'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}"
     stdin:
       value: *input-para
       transform:
@@ -2249,7 +2229,7 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
+      <text n="1" id="t-f4dc">
     stderr: |
       vrt-add-id: format replacement field s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}: key 'paragraph' not found
       vrt-add-id: non-zero status 1
@@ -2263,26 +2243,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different format specs'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:05x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]:05x}-{id:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-0b92f-f4dc">
-      <sentence a="a" id="s-b92f+f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-0f4dc-f4cb">
+      <sentence a="a" id="s-f4dc+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-0b92f-f4cb">
-      <sentence a="b" id="s-b92f+f4cb-7475">
+      <paragraph p="p2" id="p-0f4dc-3bec">
+      <sentence a="b" id="s-f4dc+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-0294c-16a6">
-      <sentence a="c" id="s-294c+16a6-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-0c2c0-95da">
+      <sentence a="c" id="s-c2c0+95da-0372">
       c
       </sentence>
       </paragraph>
@@ -2300,26 +2280,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different format specs (one with empty)'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]}-{id:04x}" --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-b92f-f4dc">
-      <sentence a="a" id="s-b92f+f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4dc-f4cb">
+      <sentence a="a" id="s-f4dc+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b92f-f4cb">
-      <sentence a="b" id="s-b92f+f4cb-7475">
+      <paragraph p="p2" id="p-f4dc-3bec">
+      <sentence a="b" id="s-f4dc+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-294c-16a6">
-      <sentence a="c" id="s-294c+16a6-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-c2c0-95da">
+      <sentence a="c" id="s-c2c0+95da-0372">
       c
       </sentence>
       </paragraph>
@@ -2328,26 +2308,26 @@
 
 - name: 'vrt-add-id: text, paragraph, sentence; idnum[elem] with different but equal format specs (with and without "d")'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:05d}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:05}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:05}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:05d}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]:05}-{id:04x}" --element=sentence --format="s-{idnum[text]:05}+{idnum[paragraph]:04x}-{id:04x}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-47407">
-      <paragraph p="p1" id="p-47407-f4dc">
-      <sentence a="a" id="s-47407+f4dc-a6de">
+      <text n="1" id="t-62684">
+      <paragraph p="p1" id="p-62684-f4cb">
+      <sentence a="a" id="s-62684+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-47407-f4cb">
-      <sentence a="b" id="s-47407+f4cb-7475">
+      <paragraph p="p2" id="p-62684-3bec">
+      <sentence a="b" id="s-62684+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-10572">
-      <paragraph p="p3" id="p-10572-16a6">
-      <sentence a="c" id="s-10572+16a6-1f16">
+      <text n="2" id="t-49856">
+      <paragraph p="p3" id="p-49856-95da">
+      <sentence a="c" id="s-49856+95da-0372">
       c
       </sentence>
       </paragraph>
@@ -2357,28 +2337,28 @@
 - name: 'vrt-add-id: text, paragraph, sentence; id and idnum[elem] without format spec (using default)'
   input:
     cmdline:
-    - vrt-add-id --id=id --type=random --max=2^16 --format="{id}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]}-{id}" --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}"
     # With idnum[elem] for the current element
-    - vrt-add-id --id=id --type=random --max=2^16 --format="{idnum[text]}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{idnum[text]}" --element=text --prefix="t-" --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]}" --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-b92f-f4dc">
-      <sentence a="a" id="s-b92f+f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4dc-f4cb">
+      <sentence a="a" id="s-f4dc+f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b92f-f4cb">
-      <sentence a="b" id="s-b92f+f4cb-7475">
+      <paragraph p="p2" id="p-f4dc-3bec">
+      <sentence a="b" id="s-f4dc+3bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-294c-16a6">
-      <sentence a="c" id="s-294c+16a6-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-c2c0-95da">
+      <sentence a="c" id="s-c2c0+95da-0372">
       c
       </sentence>
       </paragraph>
@@ -2388,28 +2368,28 @@
 - name: 'vrt-add-id: text, paragraph, sentence; id with non-default format spec, referred to from another element format (without format spec, using the same)'
   input:
     cmdline:
-    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="t-{id}" --seed=0 --element=paragraph --format="p-{idnum[text]}-{id:06x}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --element=text --format="t-{id}" --element=paragraph --format="p-{idnum[text]}-{id:06x}" --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{id}"
     # With idnum[elem] for the current element
-    - vrt-add-id --id=id --type=random --max=2^16 --element=text --format="t-{idnum[text]}" --seed=0 --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]:06x}" --seed=1 --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}" --seed=2
+    - vrt-add-id --id=id --type=random --seed=1 --max=2^16 --element=text --format="t-{idnum[text]}" --element=paragraph --format="p-{idnum[text]}-{idnum[paragraph]:06x}" --element=sentence --format="s-{idnum[text]}+{idnum[paragraph]}-{idnum[sentence]}"
     stdin: *input-para
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b92f">
-      <paragraph p="p1" id="p-b92f-00f4dc">
-      <sentence a="a" id="s-b92f+00f4dc-a6de">
+      <text n="1" id="t-f4dc">
+      <paragraph p="p1" id="p-f4dc-00f4cb">
+      <sentence a="a" id="s-f4dc+00f4cb-16a6">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b92f-00f4cb">
-      <sentence a="b" id="s-b92f+00f4cb-7475">
+      <paragraph p="p2" id="p-f4dc-003bec">
+      <sentence a="b" id="s-f4dc+003bec-ddd8">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-294c">
-      <paragraph p="p3" id="p-294c-0016a6">
-      <sentence a="c" id="s-294c+0016a6-1f16">
+      <text n="2" id="t-c2c0">
+      <paragraph p="p3" id="p-c2c0-0095da">
+      <sentence a="c" id="s-c2c0+0095da-0372">
       c
       </sentence>
       </paragraph>
@@ -2424,7 +2404,7 @@
 
 - name: 'vrt-add-id: --verbose; text, paragraph, sentence with some common options'
   input:
-    cmdline: vrt-add-id --id=id --type=random --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2 --verbose
+    cmdline: vrt-add-id --id=id --type=random --seed=1 --max=2^16 --format="{id:04x}" --element=text --prefix="t-" --element=paragraph --prefix="p-" --element=sentence --prefix="s-" --verbose
     stdin: *input-para
   output:
     stdout: *output-para-1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1412,6 +1412,25 @@
   - {}
   - *transf-no-optimize
 
+- name: 'vrt-add-id: --format referring to idnum of a specified element that is not in input'
+  input:
+    cmdline: vrt-add-id --seed=1 --element=text --format="{id:08x}" --element=sentence --format="{idnum[text]}-{id:08x}"
+    stdin:
+      value: *input-1
+      transform:
+        replace: '/text/text1/'
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text1 n="1">
+    stderr: |
+      vrt-add-id: format replacement field {idnum[text]}-{id:08x}: key 'text' not found
+      vrt-add-id: non-zero status 1
+    returncode: 1
+  transform:
+  - {}
+  - *transf-no-optimize
+
 
 # Multiple different elements
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1048,6 +1048,65 @@
         vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
+- name: 'vrt-add-id: {id} with different format specs'
+  input:
+    cmdline: vrt-add-id --type=counter --format="{id:<1d}" --verbose
+    stdin: *input-1
+  output:
+    stdout: *output-1-s3
+    stderr: |
+      vrt-add-id: using the faster method
+      vrt-add-id: added 3 sentence ids
+  transform:
+  - {}
+  - name: format spec "<5d"
+    input:
+      cmdline:
+        replace: '/<1/<5/'
+    output-expected:
+      stdout:
+        replace: '/(id=".)/\1    /'
+  - name: format spec ">5d"
+    input:
+      cmdline:
+        replace: '/<1/>5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="    \1/'
+  - name: format spec "^5d"
+    input:
+      cmdline:
+        replace: '/<1/^5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="  \1  /'
+  - name: format spec "-^5d"
+    input:
+      cmdline:
+        replace: '/<1/-^5/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="--\1--/'
+  - name: format spec "'^5d"
+    input:
+      cmdline:
+        replace: "/<1/'^5/"
+    output-expected:
+      stdout:
+        replace: "/id=\"(.)/id=\"''\\1''/"
+  - name: format spec "#04x"
+    input:
+      cmdline:
+        replace: '/<1d/#04x/'
+    output-expected:
+      stdout:
+        replace: '/id="(.)/id="0x0\1/'
+  - name: --no-optimize
+    input: *cmdline-no-optimize
+    output-expected:
+      stderr:
+        replace: '/faster method/slower method because of --no-optimize/'
+
 
 # --hash
 
@@ -2233,68 +2292,6 @@
     output-expected:
       stderr:
         replace: '/faster method/slower method because of --no-optimize/'
-
-- name: 'vrt-add-id: --verbose; {id} with different format specifications (slower method)'
-  input:
-    cmdline: vrt-add-id --type=counter --format="{id:<1d}" --verbose
-    stdin: *input-1
-  output:
-    stdout: *output-1-s3
-    stderr: |
-      vrt-add-id: using the slower method because of format specification not matching "[0-9]*[dxX]?": {id:<1d}
-      vrt-add-id: added 3 sentence ids
-  transform:
-  - {}
-  - name: format spec "<5d"
-    input:
-      cmdline:
-        replace: '/<1/<5/'
-    output-expected:
-      stdout:
-        replace: '/(id=".)/\1    /'
-      stderr:
-        replace: '/<1/<5/'
-  - name: format spec ">5d"
-    input:
-      cmdline:
-        replace: '/<1/>5/'
-    output-expected:
-      stdout:
-        replace: '/id="(.)/id="    \1/'
-      stderr:
-        replace: '/<1/>5/'
-  - name: format spec "^5d"
-    input:
-      cmdline:
-        replace: '/<1/^5/'
-    output-expected:
-      stdout:
-        replace: '/id="(.)/id="  \1  /'
-      stderr:
-        replace: '/<1/^5/'
-  - name: format spec "-^5d"
-    input:
-      cmdline:
-        replace: '/<1/-^5/'
-    output-expected:
-      stdout:
-        replace: '/id="(.)/id="--\1--/'
-      stderr:
-        replace: '/<1/-^5/'
-  - name: format spec "#04x"
-    input:
-      cmdline:
-        replace: '/<1d/#04x/'
-    output-expected:
-      stdout:
-        replace: '/id="(.)/id="0x0\1/'
-      stderr:
-        replace: '/<1d/#04x/'
-  - name: --no-optimize
-    input: *cmdline-no-optimize
-    output-expected:
-      stderr:
-        replace: '/format specification.*/--no-optimize/'
 
 - name: 'vrt-add-id: --verbose; slower method because not all types of elements occurred in input'
   input:

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -537,7 +537,7 @@
     cmdline: vrt-add-id --type=random --end=2^8 --seed=1
     stdin: *input-1
   output:
-    stdout: |
+    stdout: &stdout-random-256-seed-1 |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
       <sentence a="a" id="56">
@@ -608,7 +608,7 @@
       c
       </sentence>
       </text>
-  transform: &transform-fast-t2s3
+  transform: &transform-fast-t2s3-seed
   - {}
   # Default --seed, same value explicitly for sentence
   - input:
@@ -631,6 +631,19 @@
         set-value: |
           vrt-add-id: using the slower method because of --no-optimize
           vrt-add-id: added 2 text ids, 3 sentence ids
+  # Read seed from file
+  - input:
+      cmdline:
+        replace: '/seed=1/seed="<seed.txt"/'
+      file:seed.txt:
+        set-value: '1'
+  # Read seed from file, explicitly the same seed for sentence
+  - input:
+      cmdline:
+      - replace: '/seed=1/seed="<seed.txt"/'
+      - append: ' --seed="<seed.txt"'
+      file:seed.txt:
+        set-value: '1'
 
 - name: 'vrt-add-id: --type=random, explicitly same for multiple element types'
   input:
@@ -652,7 +665,86 @@
       c
       </sentence>
       </text>
-  transform: *transform-fast-t2s3
+  transform: *transform-fast-t2s3-seed
+
+
+# Random seed from file
+
+- name: 'vrt-add-id: --type=random, seed from file'
+  input:
+    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    stdin: *input-1
+    file:seed.txt: '1'
+  output:
+    stdout: *stdout-random-256-seed-1
+  transform:
+  - {}
+  - *transf-no-optimize
+  - *transf-verbose-fast-s3
+  - *transf-verbose-noopt-s3
+  # Test that the seed read from file produces the same result as the
+  # same seed literally
+  - input:
+      cmdline:
+        replace: '/<seed\.txt/1/'
+  # Test that spaces around the file name are stripped
+  - input:
+      cmdline:
+        replace: '/<seed.txt/< \tseed.txt \t/'
+
+- name: 'vrt-add-id: --type=random, seed from 1 MiB file'
+  input:
+    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    stdin: *input-1
+    file:seed.txt:
+      value: ''
+      transform:
+        python: return pow(2, 20) * '0'
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="c7">
+      a
+      </sentence>
+      <sentence a="b" id="94">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="b6">
+      c
+      </sentence>
+      </text>
+  transform:
+  - {}
+  - *transf-no-optimize
+  - *transf-verbose-fast-s3
+  - *transf-verbose-noopt-s3
+  # The seed file with something appended should produce the same
+  # result, as only the first 1 MiB of the seed file is used
+  - input:
+      file:seed.txt:
+        append: 'foobar'
+  # A one byte shorter seed file should produce different ids
+  - input:
+      file:seed.txt:
+        python: return value[:-1]
+    output-expected:
+      stdout:
+      - replace: '/c7/72/'
+      - replace: '/94/ba/'
+      - replace: '/b6/97/'
+
+- name: 'vrt-add-id: --type=random, non-existent seed file'
+  input:
+    cmdline: vrt-add-id --type=random --end=2^8 --seed="<seed.txt"
+    stdin: *input-1
+  output:
+    stdout: ''
+    stderr: |
+      vrt-add-id: error: cannot read random seed from file seed.txt: [Errno 2] No such file or directory: 'seed.txt'
+    returncode: 1
 
 
 # --format

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -449,15 +449,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="def75f99">
+      <sentence a="a" id="e91f0e05">
       a
       </sentence>
-      <sentence a="b" id="013ed027">
+      <sentence a="b" id="5ea89fed">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="0f1462b4">
+      <sentence a="c" id="0ab0a68c">
       c
       </sentence>
       </text>
@@ -468,7 +468,7 @@
 
 - name: 'vrt-add-id: --type=random --end=3'
   input:
-    cmdline: vrt-add-id --type=random --end=3 --seed=1
+    cmdline: vrt-add-id --type=random --end=3 --seed=2
     stdin: *input-1
   output:
     stdout: |
@@ -496,15 +496,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="0b">
+      <sentence a="a" id="05">
       a
       </sentence>
-      <sentence a="b" id="10">
+      <sentence a="b" id="0b">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="12">
+      <sentence a="c" id="08">
       c
       </sentence>
       </text>
@@ -518,15 +518,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="b66">
+      <sentence a="a" id="568">
       a
       </sentence>
-      <sentence a="b" id="027">
+      <sentence a="b" id="bd5">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="bb1">
+      <sentence a="c" id="8af">
       c
       </sentence>
       </text>
@@ -540,15 +540,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="b6">
+      <sentence a="a" id="56">
       a
       </sentence>
-      <sentence a="b" id="02">
+      <sentence a="b" id="bd">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="bb">
+      <sentence a="c" id="8a">
       c
       </sentence>
       </text>
@@ -556,7 +556,7 @@
 
 - name: 'vrt-add-id: --type=random --end=2 (too small value)'
   input:
-    cmdline: vrt-add-id --type=random --end=2 --seed=1
+    cmdline: vrt-add-id --type=random --end=2 --seed=2
     stdin: *input-1
   output:
     stdout: |
@@ -584,6 +584,75 @@
         prepend: |
           vrt-add-id: using the faster method
   - *transf-verbose-noopt-prepend
+
+
+# --type=random --seed
+
+- name: 'vrt-add-id: --type=random, default seed for multiple element types'
+  input:
+    cmdline: vrt-add-id --type=random --seed=1 --end=0x100 --element=text --element=sentence
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="e9">
+      <sentence a="a" id="56">
+      a
+      </sentence>
+      <sentence a="b" id="bd">
+      b
+      </sentence>
+      </text>
+      <text n="2" id="24">
+      <sentence a="c" id="8a">
+      c
+      </sentence>
+      </text>
+  transform: &transform-fast-t2s3
+  - {}
+  # Default --seed, same value explicitly for sentence
+  - input:
+      cmdline:
+        append: ' --seed=1'
+  - *transf-no-optimize
+  # Test the command with --verbose
+  - &transf-verbose-fast-t2s3
+    input: *cmdline-verbose
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the faster method
+          vrt-add-id: added 2 text ids, 3 sentence ids
+  # Test the command with --verbose --no-optimize
+  - &transf-verbose-noopt-t2s3
+    input: *cmdline-verbose-no-optimize
+    output-expected:
+      stderr:
+        set-value: |
+          vrt-add-id: using the slower method because of --no-optimize
+          vrt-add-id: added 2 text ids, 3 sentence ids
+
+- name: 'vrt-add-id: --type=random, explicitly same for multiple element types'
+  input:
+    cmdline: vrt-add-id --type=random --end=0x100 --element=text --seed=1 --element=sentence --seed=1
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="f4">
+      <sentence a="a" id="f4">
+      a
+      </sentence>
+      <sentence a="b" id="16">
+      b
+      </sentence>
+      </text>
+      <text n="2" id="16">
+      <sentence a="c" id="3b">
+      c
+      </sentence>
+      </text>
+  transform: *transform-fast-t2s3
 
 
 # --format
@@ -684,15 +753,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="*005*">
+      <sentence a="a" id="*002*">
       a
       </sentence>
-      <sentence a="b" id="*008*">
+      <sentence a="b" id="*005*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="*009*">
+      <sentence a="c" id="*004*">
       c
       </sentence>
       </text>
@@ -706,15 +775,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="x-*005*">
+      <sentence a="a" id="x-*002*">
       a
       </sentence>
-      <sentence a="b" id="x-*008*">
+      <sentence a="b" id="x-*005*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="x-*009*">
+      <sentence a="c" id="x-*004*">
       c
       </sentence>
       </text>
@@ -728,15 +797,15 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <sentence a="a" id="*045-2d*">
+      <sentence a="a" id="*021-15*">
       a
       </sentence>
-      <sentence a="b" id="*065-41*">
+      <sentence a="b" id="*047-2f*">
       b
       </sentence>
       </text>
       <text n="2">
-      <sentence a="c" id="*072-48*">
+      <sentence a="c" id="*034-22*">
       c
       </sentence>
       </text>
@@ -982,21 +1051,21 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text x="1" xid="1-b1fd">
-      <paragraph x="p1" xid="p1-b1fd">
-      <sentence x="a" xid="a-b1fd">
+      <text x="1" xid="1-9031">
+      <paragraph x="p1" xid="p1-678f">
+      <sentence x="a" xid="a-3277">
       a
       </sentence>
       </paragraph>
-      <paragraph x="p2" xid="p2-391f">
-      <sentence x="b" xid="b-391f">
+      <paragraph x="p2" xid="p2-2af3">
+      <sentence x="b" xid="b-960b">
       b
       </sentence>
       </paragraph>
       </text>
-      <text x="2" xid="2-391f">
-      <paragraph x="p3" xid="p3-3d2b">
-      <sentence x="c" xid="c-3d2b">
+      <text x="2" xid="2-0e08">
+      <paragraph x="p3" xid="p3-a606">
+      <sentence x="c" xid="c-68c2">
       c
       </sentence>
       </paragraph>
@@ -1202,19 +1271,19 @@
       <!-- #vrt positional-attributes: word -->
       <text n="1" tid="0">
       <paragraph p="p1" pid="p-0a">
-      <sentence a="a" sid="b1fd">
+      <sentence a="a" sid="b92f">
       a
       </sentence>
       </paragraph>
       <paragraph p="p2" pid="p-0b">
-      <sentence a="b" sid="391f">
+      <sentence a="b" sid="294c">
       b
       </sentence>
       </paragraph>
       </text>
       <text n="2" tid="1">
       <paragraph p="p3" pid="p-0c">
-      <sentence a="c" sid="3d2b">
+      <sentence a="c" sid="8350">
       c
       </sentence>
       </paragraph>
@@ -1244,21 +1313,21 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" xid="b1fd">
-      <paragraph p="p1" xid="b1fd">
-      <sentence a="a" xid="b1fd">
+      <text n="1" xid="9031">
+      <paragraph p="p1" xid="678f">
+      <sentence a="a" xid="3277">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" xid="391f">
-      <sentence a="b" xid="391f">
+      <paragraph p="p2" xid="2af3">
+      <sentence a="b" xid="960b">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" xid="391f">
-      <paragraph p="p3" xid="3d2b">
-      <sentence a="c" xid="3d2b">
+      <text n="2" xid="0e08">
+      <paragraph p="p3" xid="a606">
+      <sentence a="c" xid="68c2">
       c
       </sentence>
       </paragraph>
@@ -1300,21 +1369,21 @@
   output:
     stdout: &output-para-1 |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b1fd">
-      <paragraph p="p1" id="p-b667">
-      <sentence a="a" id="s-7b6f">
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-f4dc">
+      <sentence a="a" id="s-a6de">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-027d">
-      <sentence a="b" id="s-50dc">
+      <paragraph p="p2" id="p-f4cb">
+      <sentence a="b" id="s-7475">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-391f">
-      <paragraph p="p3" id="p-bb1d">
-      <sentence a="c" id="s-275c">
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-16a6">
+      <sentence a="c" id="s-1f16">
       c
       </sentence>
       </paragraph>
@@ -1328,21 +1397,21 @@
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b1fd">
-      <paragraph p="p1" id="t-b1fd-p-b667">
-      <sentence a="a" id="t-b1fd-p-b667-s-7b6f">
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="t-b92f-p-f4dc">
+      <sentence a="a" id="t-b92f-p-f4dc-s-a6de">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="t-b1fd-p-027d">
-      <sentence a="b" id="t-b1fd-p-027d-s-50dc">
+      <paragraph p="p2" id="t-b92f-p-f4cb">
+      <sentence a="b" id="t-b92f-p-f4cb-s-7475">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-391f">
-      <paragraph p="p3" id="t-391f-p-bb1d">
-      <sentence a="c" id="t-391f-p-bb1d-s-275c">
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="t-294c-p-16a6">
+      <sentence a="c" id="t-294c-p-16a6-s-1f16">
       c
       </sentence>
       </paragraph>
@@ -1541,21 +1610,21 @@
   output:
     stdout: &output-para-subst |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" id="t-b1fd">
-      <paragraph p="p1" id="p-b1fd-b667">
-      <sentence a="a" id="s-b1fd+b667-7b6f">
+      <text n="1" id="t-b92f">
+      <paragraph p="p1" id="p-b92f-f4dc">
+      <sentence a="a" id="s-b92f+f4dc-a6de">
       a
       </sentence>
       </paragraph>
-      <paragraph p="p2" id="p-b1fd-027d">
-      <sentence a="b" id="s-b1fd+027d-50dc">
+      <paragraph p="p2" id="p-b92f-f4cb">
+      <sentence a="b" id="s-b92f+f4cb-7475">
       b
       </sentence>
       </paragraph>
       </text>
-      <text n="2" id="t-391f">
-      <paragraph p="p3" id="p-391f-bb1d">
-      <sentence a="c" id="s-391f+bb1d-275c">
+      <text n="2" id="t-294c">
+      <paragraph p="p3" id="p-294c-16a6">
+      <sentence a="c" id="s-294c+16a6-1f16">
       c
       </sentence>
       </paragraph>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1060,7 +1060,7 @@
     cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{text[id]/t-//}-{id:04x}" --seed=1 --element=sentence --format="s-{paragraph[id]/p-//,/-/+/}-{id:04x}" --seed=2
     stdin: *input-para
   output:
-    stdout: |
+    stdout: &output-para-subst |
       <!-- #vrt positional-attributes: word -->
       <text n="1" id="t-b1fd">
       <paragraph p="p1" id="p-b1fd-b667">
@@ -1081,3 +1081,15 @@
       </sentence>
       </paragraph>
       </text>
+
+
+# idnum[elem] in format
+
+- name: 'vrt-add-id: text, paragraph, sentence; format referring to idnum[elem]'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="p-{idnum[text]:04x}-{id:04x}" --seed=1 --element=sentence --format="s-{idnum[text]:04x}+{idnum[paragraph]:04x}-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    # This is another way to achieve the same result as with the
+    # substitutions above
+    stdout: *output-para-subst

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -656,7 +656,7 @@
 - name: 'vrt-add-id: --format with {elem[attr]} for enclosing elements'
   input:
     cmdline: vrt-add-id --counter --format="{text[n]:0>2s}-{paragraph[p]}-{sentence[a]}-{id:03d}"
-    stdin: |
+    stdin: &input-para |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
       <paragraph p="p1">
@@ -695,6 +695,144 @@
       <text n="2">
       <paragraph p="p3">
       <sentence a="c" id="02-p3-c-003">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+
+# Multiple different elements
+
+- name: 'vrt-add-id: text, paragraph, sentence with completely different options'
+  input:
+    cmdline: vrt-add-id --element=text --counter --start=0 --id=tid --element=paragraph --counter --start=10 --id=pid --format="p-{id:02x}" --element=sentence --random --id=sid --seed=0 --end=2^16 --format="{id:04x}"
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" tid="0">
+      <paragraph p="p1" pid="p-0a">
+      <sentence a="a" sid="b1fd">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" pid="p-0b">
+      <sentence a="b" sid="391f">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" tid="1">
+      <paragraph p="p3" pid="p-0c">
+      <sentence a="c" sid="3d2b">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+- name: 'vrt-add-id: text, paragraph, sentence with same options'
+  input:
+    cmdline: vrt-add-id --id=xid --random --seed=0 --end=2^16 --format="{id:04x}" --element=text --element=paragraph --element=sentence
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" xid="b1fd">
+      <paragraph p="p1" xid="b1fd">
+      <sentence a="a" xid="b1fd">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" xid="391f">
+      <sentence a="b" xid="391f">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" xid="391f">
+      <paragraph p="p3" xid="3d2b">
+      <sentence a="c" xid="3d2b">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+- name: 'vrt-add-id: text, paragraph, sentence with default options'
+  input:
+    cmdline: vrt-add-id --element=text --element=paragraph --element=sentence
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="1">
+      <paragraph p="p1" id="1">
+      <sentence a="a" id="1">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="2">
+      <sentence a="b" id="2">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="2">
+      <paragraph p="p3" id="3">
+      <sentence a="c" id="3">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+- name: 'vrt-add-id: text, paragraph, sentence with some common options'
+  input:
+    cmdline: vrt-add-id --id=id --random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --prefix="p-" --seed=1 --element=sentence --prefix="s-" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b1fd">
+      <paragraph p="p1" id="p-b667">
+      <sentence a="a" id="s-7b6f">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="p-027d">
+      <sentence a="b" id="s-50dc">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-391f">
+      <paragraph p="p3" id="p-bb1d">
+      <sentence a="c" id="s-275c">
+      c
+      </sentence>
+      </paragraph>
+      </text>
+
+- name: 'vrt-add-id: text, paragraph, sentence; format referring to added ids'
+  input:
+    cmdline: vrt-add-id --id=id --type=random --end=2^16 --format="{id:04x}" --element=text --prefix="t-" --seed=0 --element=paragraph --format="{text[id]}-p-{id:04x}" --seed=1 --element=sentence --format="{paragraph[id]}-s-{id:04x}" --seed=2
+    stdin: *input-para
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1" id="t-b1fd">
+      <paragraph p="p1" id="t-b1fd-p-b667">
+      <sentence a="a" id="t-b1fd-p-b667-s-7b6f">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph p="p2" id="t-b1fd-p-027d">
+      <sentence a="b" id="t-b1fd-p-027d-s-50dc">
+      b
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2" id="t-391f">
+      <paragraph p="p3" id="t-391f-p-bb1d">
+      <sentence a="c" id="t-391f-p-bb1d-s-275c">
       c
       </sentence>
       </paragraph>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -496,6 +496,50 @@
       </text>
   transform: *no-optimize
 
+- name: 'vrt-add-id: --type=counter --format without width'
+  input:
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:x}*"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="*a*">
+      a
+      </sentence>
+      <sentence a="b" id="*b*">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="*c*">
+      c
+      </sentence>
+      </text>
+  transform: *no-optimize
+
+- name: 'vrt-add-id: --type=counter --format with width, default type'
+  input:
+    cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03}*"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence a="a" id="*010*">
+      a
+      </sentence>
+      <sentence a="b" id="*011*">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence a="c" id="*012*">
+      c
+      </sentence>
+      </text>
+  transform: *no-optimize
+
 - name: 'vrt-add-id: --type=counter --format --prefix'
   input:
     cmdline: vrt-add-id --type=counter --start=10 --format="*{id:03x}*" --prefix="x-"

--- a/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml
@@ -1676,7 +1676,7 @@
         vrt-add-id: added 3 sentence ids
   - *transf-verbose-noopt-s3
 
-- name: 'vrt-add-id: --rename without argument, existing attribute'
+- name: 'vrt-add-id: --rename, existing attribute'
   input:
     cmdline: vrt-add-id --type=counter --id=a --rename
     stdin: *input-multiattr
@@ -1684,81 +1684,37 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text a="a" n="1" n_1="a" n_2="b">
-      <sentence id="1" a_orig="a" a="1">
+      <sentence id="1" a_1="a" a="1">
       a
       </sentence>
-      <sentence id="2" a_orig="b" a="2">
+      <sentence id="2" a_1="b" a="2">
       b
       </sentence>
       </text>
       <text a="a" n="2" n_1="b" n_2="c">
-      <sentence id="3" a_orig="c" a="3">
+      <sentence id="3" a_1="c" a="3">
       c
       </sentence>
       </text>
   transform: *transform-rename-s3
 
-- name: 'vrt-add-id: --rename fixed name, existing attribute'
+- name: 'vrt-add-id: --rename, text and sentence, existing attributes'
   input:
-    cmdline: vrt-add-id --type=counter --id=a --rename=b
+    cmdline: vrt-add-id --type=counter --rename --element=text --id=n_1 --element=sentence --id=a
     stdin: *input-multiattr
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text a="a" n="1" n_1="a" n_2="b">
-      <sentence id="1" b="a" a="1">
+      <text a="a" n="1" n_2="b" n_1_1="a" n_1="1">
+      <sentence id="1" a_1="a" a="1">
       a
       </sentence>
-      <sentence id="2" b="b" a="2">
+      <sentence id="2" a_1="b" a="2">
       b
       </sentence>
       </text>
-      <text a="a" n="2" n_1="b" n_2="c">
-      <sentence id="3" b="c" a="3">
-      c
-      </sentence>
-      </text>
-  transform: *transform-rename-s3
-
-- name: 'vrt-add-id: --rename with {}, text and sentence, existing attributes'
-  input:
-    cmdline: vrt-add-id --type=counter --rename="{}_" --element=text --id=n_1 --element=sentence --id=a
-    stdin: *input-multiattr
-  output:
-    stdout: |
-      <!-- #vrt positional-attributes: word -->
-      <text a="a" n="1" n_2="b" n_1_="a" n_1="1">
-      <sentence id="1" a_="a" a="1">
-      a
-      </sentence>
-      <sentence id="2" a_="b" a="2">
-      b
-      </sentence>
-      </text>
-      <text a="a" n="2" n_2="c" n_1_="b" n_1="2">
-      <sentence id="3" a_="c" a="3">
-      c
-      </sentence>
-      </text>
-  transform: *no-optimize
-
-- name: 'vrt-add-id: text and sentence, different renames, existing attributes'
-  input:
-    cmdline: vrt-add-id --type=counter --element=text --id=n_1 --rename="{}_" --element=sentence --id=a --rename="{}a"
-    stdin: *input-multiattr
-  output:
-    stdout: |
-      <!-- #vrt positional-attributes: word -->
-      <text a="a" n="1" n_2="b" n_1_="a" n_1="1">
-      <sentence id="1" aa="a" a="1">
-      a
-      </sentence>
-      <sentence id="2" aa="b" a="2">
-      b
-      </sentence>
-      </text>
-      <text a="a" n="2" n_2="c" n_1_="b" n_1="2">
-      <sentence id="3" aa="c" a="3">
+      <text a="a" n="2" n_2="c" n_1_1="b" n_1="2">
+      <sentence id="3" a_1="c" a="3">
       c
       </sentence>
       </text>
@@ -1779,23 +1735,23 @@
         vrt-add-id: using the slower method because of --no-optimize
         vrt-add-id: added 2 text ids, 3 sentence ids
 
-- name: 'vrt-add-id: text and sentence, rename requiring suffix _N, existing attributes'
+- name: 'vrt-add-id: text and sentence, rename, N > 1, existing attributes'
   input:
-    cmdline: vrt-add-id --type=counter --element=text --id=a --rename=n --element=sentence --id=a --rename=id
+    cmdline: vrt-add-id --type=counter --start=0 --rename --element=text --id=n --element=sentence --id=id
     stdin: *input-multiattr
   output:
     stdout: |
       <!-- #vrt positional-attributes: word -->
-      <text n="1" n_1="a" n_2="b" n_3="a" a="1">
-      <sentence id="1" id_1="a" a="1">
+      <text a="a" n_1="a" n_2="b" n_3="1" n="0">
+      <sentence a="a" id_1="1" id="0">
       a
       </sentence>
-      <sentence id="2" id_1="b" a="2">
+      <sentence a="b" id_1="2" id="1">
       b
       </sentence>
       </text>
-      <text n="2" n_1="b" n_2="c" n_3="a" a="2">
-      <sentence id="3" id_1="c" a="3">
+      <text a="a" n_1="b" n_2="c" n_3="2" n="1">
+      <sentence a="c" id_1="3" id="2">
       c
       </sentence>
       </text>

--- a/vrt-tools/tests/test_scripttestlib.py
+++ b/vrt-tools/tests/test_scripttestlib.py
@@ -382,6 +382,7 @@ _testcase_files_content = [
              },
              'output': {
                  'stdout': [
+                     # "in", "not-in" with list value
                      {
                          'test': 'in',
                          'value': [
@@ -392,10 +393,41 @@ _testcase_files_content = [
                      {
                          'test': 'not-in',
                          'value': [
-                            'a',
+                            'test0\ntest1\ntest2\n',
                             'b',
                          ],
                      },
+                     # "in", "not-in" with string value
+                     {
+                         'test': 'in',
+                         'value': 'test0\ntest1\ntest2\n',
+                     },
+                     {
+                         'test': 'not-in',
+                         'value': 'test0\ntest2\n',
+                     },
+                     # "in", "not-in" with test name as key, str value
+                     {
+                         'in': 'test0\ntest1\ntest2\n',
+                         'not-in': 'test0\ntest2\n',
+                     },
+                     # "in", "not-in" with test name as key, list value
+                     {
+                         'in': [
+                             [
+                                 'a',
+                                 'test1\ntest2\n',
+                             ],
+                             'test0\ntest1\ntest2\n',
+                         ],
+                     },
+                     {
+                         'not-in': [[
+                            'test0\ntest1\ntest2\n',
+                            'b',
+                         ]],
+                     },
+                     # "contains", "not-contains"
                      {
                          'test': 'contains',
                          'value': 'test',
@@ -473,6 +505,22 @@ _testcase_files_content = [
                  'stdout': '',
                  'stderr': '',
                  'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: (non-)existence of files',
+             'input': {
+                 'cmdline': 'printf "test\ntest\n" > test.out',
+                 'shell': True,
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': '',
+                 'returncode': 0,
+                 'file:test.out': {
+                     '!=': None,
+                 },
+                 'file:test2.out': None,
              },
          },
          # Test default values
@@ -819,6 +867,22 @@ _testcase_files_content = [
              },
          },
          {
+             'name': 'Test: completely replace output file content',
+             'input': {
+                 'cmdline': 'cat > file.out',
+                 'shell': True,
+                 'stdin': 'foo\nbar\nbaz\n'
+             },
+             'output': {
+                 'file:file.out': {
+                     'value': 'bar\n',
+                     'transform-expected': {
+                         'set-value': 'foo\nbar\nbaz\n',
+                     },
+                 },
+             },
+         },
+         {
              'name': 'Test: transform stdin with shell (+ append)',
              'input': {
                  'cmdline': 'cat',
@@ -892,6 +956,616 @@ _testcase_files_content = [
                  'stderr': '',
                  'returncode': 0,
              },
+         },
+         {
+             'name': 'Test: transform cmdline',
+             'input': {
+                 'cmdline': {
+                     'value': 'echo "foobar"',
+                     'transform': {
+                         'replace': '/foo/bar/',
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'barbar\n',
+             },
+         },
+         {
+             'name': 'Test: replace string in stdin',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'str': 'b',
+                             'with': 'x',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'foo\nxar\nxaz\n',
+             },
+         },
+         {
+             'name': 'Test: replace string in stdin, without "with"',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'str': 'b',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'foo\nar\naz\n',
+             },
+         },
+         {
+             'name': 'Test: replace string in stdin, with count',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'str': 'b',
+                             'with': 'x',
+                             'count': 1,
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'foo\nxar\nbaz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '[ao]',
+                             'with': 'V',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\nbVr\nbVz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, refer to groups',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '(.)([ao]+)',
+                             'with': '\\2\\1',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'oof\nabr\nabz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, refer to named groups',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '(?P<c>.)(?P<v>[ao]+)',
+                             'with': '\\g<v>\\g<c>',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'oof\nabr\nabz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, /.../.../',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': '/[ao]/V/',
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\nbVr\nbVz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, /.../.../, alt delim',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': '![ao]!V!',
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\nbVr\nbVz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, /.../.../, refer to groups',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': '/(?P<c>.)(?P<v>[ao]+)/\\g<v>\\g<c>/',
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'oof\nabr\nabz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, without "with"',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '[ao]',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'f\nbr\nbz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin, with "count"',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '[ao]',
+                             'with': 'V',
+                             'count': 2,
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\nbar\nbaz\n',
+             },
+         },
+         {
+             'name': 'Test: replace regex in stdin',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': {
+                             'regex': '[ao]',
+                             'with': 'V',
+                         },
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\nbVr\nbVz\n',
+             },
+         },
+         {
+             'name': 'Test: list of replacements in stdin',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': {
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform': {
+                         'replace': [
+                             {
+                                 'regex': '[ao]',
+                                 'with': 'V',
+                             },
+                             {
+                                 'str': 'b',
+                                 'with': 'x',
+                             },
+                             '/[xz]/a/',
+                         ],
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'fVV\naVr\naVa\n',
+             },
+         },
+         {
+             'name': 'Test: transformations of None',
+             'input': {
+                 'cmdline': 'cat f1.txt f2.txt f3.txt f4.txt f5.txt f6.txt f7.txt',
+                 'file:f1.txt': {
+                     'value': None,
+                     'transform': {
+                         'prepend': 'foo\n'
+                     },
+                 },
+                 'file:f2.txt': {
+                     'value': None,
+                     'transform': {
+                         'append': 'foo\n'
+                     },
+                 },
+                 'file:f3.txt': {
+                     'value': None,
+                     'transform': {
+                         'filter-out': 'o'
+                     },
+                 },
+                 'file:f4.txt': {
+                     'value': None,
+                     'transform': {
+                         'replace': '/o/x/'
+                     },
+                 },
+                 'file:f5.txt': {
+                     'value': None,
+                     'transform': {
+                         'set-value': 'zz\n'
+                     },
+                 },
+                 'file:f6.txt': {
+                     'value': None,
+                     'transform': {
+                         'python': 'return "x\\n" if value is None else "y\\n"'
+                     },
+                 },
+                 'file:f7.txt': {
+                     'value': None,
+                     'transform': {
+                         'shell': 'tr "a" "b"'
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'foo\nfoo\nzz\nx\n',
+                 'stderr': ('cat: f3.txt: No such file or directory\n'
+                            'cat: f4.txt: No such file or directory\n'
+                            'cat: f7.txt: No such file or directory\n'),
+             },
+         },
+         {
+             'name': 'Test: transformations of int: set-value',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': 'cat: foo: No such file or directory\n',
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': [
+                         {'set-value': 1},
+                     ],
+                 },
+             },
+         },
+         {
+             'name': 'Test: transformations of int: keep intact',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': 'cat: foo: No such file or directory\n',
+                 'returncode': {
+                     'value': 1,
+                     'transform-expected': [
+                         {'prepend': 2},
+                         {'append': 3},
+                         {'filter-out': '3'},
+                         {'replace': '/3/4/'},
+                         {'set-value': 'foo'},
+                         {'set-value': None},
+                     ],
+                 },
+             },
+         },
+         {
+             'name': 'Test: transformations of int: Python',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': 'cat: foo: No such file or directory\n',
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': [
+                         {'python': 'return value + 1'},
+                     ],
+                 },
+             },
+         },
+         {
+             'name': 'Test: transformations of int: shell',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': 'cat: foo: No such file or directory\n',
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': [
+                         {'shell': 'tr 0 1'},
+                     ],
+                 },
+             },
+         },
+         {
+             'name': 'Test: transformation set-value str and None',
+             'input': {
+                 'cmdline': 'cat f1.txt f2.txt f3.txt f4.txt',
+                 'file:f1.txt': {
+                     'value': 'foo\n',
+                     'transform': {
+                         # Should not change
+                         'set-value': 1,
+                     },
+                 },
+                 'file:f2.txt': {
+                     'value': 'bar\n',
+                     'transform': {
+                         # Should change
+                         'set-value': None,
+                     },
+                 },
+                 'file:f3.txt': {
+                     'value': None,
+                     'transform': {
+                         # Should not change
+                         'set-value': 1,
+                     },
+                 },
+                 'file:f4.txt': {
+                     'value': None,
+                     'transform': {
+                         # Should change
+                         'set-value': 'baz\n',
+                     },
+                 },
+             },
+             'output': {
+                 'stdout': 'foo\nbaz\n',
+                 'stderr': ('cat: f2.txt: No such file or directory\n'
+                            'cat: f3.txt: No such file or directory\n'),
+                 'returncode': 1,
+             },
+         },
+         {
+             'name': 'Test: transformations of expected list (test "in")',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\n',
+             },
+             'output': {
+                 'stdout': [
+                     {
+                         'test': 'in',
+                         'value': [
+                             'foo\nbar\n',
+                             'xxx\n',
+                         ],
+                     },
+                 ],
+             },
+             'transform': [
+                 {},
+                 {
+                     'input': {
+                         'stdin': {
+                             'prepend': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'prepend': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'append': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'filter-out': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'filter-out': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'replace': '/f/b/',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'replace': '/f/b/',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'set-value': 'zzz\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'set-value': 'zzz\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'python': 'return value[2:]',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'python': 'return value[2:]',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'shell': 'tr z x',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'shell': 'tr z x',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             # "not-in" is tested separately from "in", as
+             # transformation "set-value" would not produce
+             # correct-results for "not-in"
+             'name': 'Test: transformations of expected list (test "not-in")',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\n',
+             },
+             'output': {
+                 'stdout': [
+                     {
+                         'test': 'not-in',
+                         'value': [
+                             'foo\nbar\nbaz\n',
+                             'xxx\n',
+                         ],
+                     },
+                 ],
+             },
+             'transform': [
+                 {},
+                 {
+                     'input': {
+                         'stdin': {
+                             'prepend': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'prepend': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'append': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'filter-out': 'foo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'filter-out': 'foo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'replace': '/f/b/',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'replace': '/f/b/',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'python': 'return value[2:]',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'python': 'return value[2:]',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'shell': 'tr z x',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'shell': 'tr z x',
+                         },
+                     },
+                 },
+             ],
          },
          {
              'name': 'Test: transformation sequences',
@@ -988,6 +1662,305 @@ _testcase_files_content = [
              },
          },
          {
+             'name': 'Test: global transformation groups',
+             'input': {
+                 'cmdline': 'cat',
+                 'shell': True,
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'stdout': {
+                     'value': 'foo\nbar\nbaz\n',
+                 },
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': [
+                             {'append': 'zoo\n'},
+                             {'replace': '/o/a/'},
+                         ],
+                     },
+                     'output-expected': {
+                         'stdout': [
+                             {'append': 'zoo\n'},
+                             {'replace': '/o/a/'},
+                         ],
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'xxx\n',
+                         },
+                     },
+                     'output-actual': {
+                         'stdout': {
+                             'filter-out': 'xxx\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: global transformation group, mixing files, file:F',
+             'input': {
+                 'cmdline': 'cat input.txt > output.txt',
+                 'shell': True,
+                 'file:input.txt': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'files': {
+                     'output.txt': 'foo\nbar\nbaz\n',
+                 },
+             },
+             'transform': [
+                 {
+                     'input': {
+                         'files': {
+                             'input.txt': {
+                                 'append': 'zoo\n',
+                             },
+                         },
+                     },
+                     'output-expected': {
+                         'file:output.txt': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: global transformation group, transform cmdline',
+             'input': {
+                 'cmdline': 'cat input.txt',
+                 'shell': True,
+                 'file:input.txt': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'stdout': 'foo\nbar\nbaz\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+             'transform': [
+                 {
+                     'input': {
+                         'cmdline': {
+                             'append': ' > output.txt'
+                         },
+                     },
+                     'output-expected': {
+                         'file:output.txt': {
+                             'set-value': 'foo\nbar\nbaz\n',
+                         },
+                         'stdout': {
+                             'set-value': '',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'cmdline': {
+                             'append': ' input2.txt'
+                         },
+                         'file:input2.txt': {
+                             'set-value': 'zoo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'cmdline': {
+                             'append': ' input2.txt',
+                         },
+                     },
+                     'output-expected': {
+                         'stderr': {
+                             'set-value': 'cat: input2.txt: No such file or directory\n',
+                         },
+                         'returncode': {
+                             'set-value': 1,
+                         }
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: transformation groups and global transformations',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 # Global transformations
+                 'transform-expected': [
+                     {'filter-out': 'z'},
+                 ],
+                 'transform-actual': [
+                     {'filter-out': 'z'},
+                 ],
+                 'stdout': 'foo\nbar\nbaz\n',
+                 # After transformation: 'foo\nbar\nba\n'
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             # Global transformations applied before this
+                             'append': 'oo\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: transformation groups and file-specific transformations',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 # File-specific transformations
+                 'stdout': {
+                     # After transformation: 'foo\nbar\nba\n'
+                     'value': 'foo\nbar\nbaz\n',
+                     'transform-expected': [
+                         {'filter-out': 'z'},
+                     ],
+                     'transform-actual': [
+                         {'filter-out': 'z'},
+                     ],
+                 },
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'zoo\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             # File-specific transformations applied before this
+                             'append': 'oo\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: transformation groups and test-specific transformations',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'stdout': [
+                     {'value': 'foo\nbar\nbaz\n'},
+                     # Test-specific transformations
+                     {
+                         'transform-expected': [
+                             {'filter-out': 'x'},
+                         ],
+                         'transform-actual': [
+                             {'filter-out': 'z'},
+                         ],
+                     },
+                     # After transformation: 'foo\nbar\nba\n'
+                     {'value': 'foox\nbarx\nba\n'},
+                 ],
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     # These should work for the above value tests
+                     # both before and after the test-specific
+                     # transformations
+                     'input': {
+                         'stdin': {
+                             'append': 'yyy\n',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'append': 'yyy\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: transformation groups and dict with test names',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'stdout': {
+                     '==': 'foo\nbar\nbaz\n',
+                     '!=': 'goo',
+                     'contains': [
+                         'foo\n',
+                         'baz\n',
+                     ],
+                     'regex': 'b..\n',
+                 },
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     'input': {
+                         'stdin': {
+                             'replace': '/\n/yyy\n/',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'replace': '/\n/yyy\n/',
+                         },
+                     },
+                 },
+                 {
+                     'input': {
+                         'stdin': {
+                             'append': 'xxx\n',
+                         },
+                     },
+                     'output-actual': {
+                         'stdout': {
+                             'filter-out': 'xxx\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
              'name': 'Test: "files" in input and output',
              'input': {
                  'cmdline': 'cat a.txt b.txt | tee out1.txt > out2.txt',
@@ -1008,6 +1981,183 @@ _testcase_files_content = [
                      },
                  },
                  'stdout': '',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         # Multiple inputs with the same output
+         {
+             'name': 'Test: multiple inputs with same output',
+             'input': [
+                 {
+                     'name': 'cat file',
+                     'cmdline': 'cat infile.txt',
+                     'file:infile.txt': 'test1\ntest2\n'
+                 },
+                 {
+                     'name': 'cat redirect file',
+                     'cmdline': 'cat < infile.txt',
+                     'shell': True,
+                     'file:infile.txt': 'test1\ntest2\n'
+                 },
+                 {
+                     'name': 'cat stdin',
+                     'cmdline': 'cat',
+                     'stdin': 'test1\ntest2\n'
+                 },
+                 {
+                     # Without 'name'
+                     'prog': 'cat',
+                     'stdin': 'test1\ntest2\n'
+                 },
+                 {
+                     'name': 'printf',
+                     'cmdline': 'printf "test1\\ntest2\\n"',
+                     'shell': True,
+                 },
+             ],
+             'output': {
+                 'stdout': 'test1\ntest2\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: multiple cmdlines in input',
+             'input': {
+                 'cmdline': [
+                     'cat infile.txt',
+                     'cat < infile.txt',
+                     'printf "test1\\ntest2\\n"',
+                 ],
+                 'shell': True,
+                 'file:infile.txt': 'test1\ntest2\n'
+             },
+             'output': {
+                 'stdout': 'test1\ntest2\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: multiple cmdlines and alternative input files',
+             'input': {
+                 'cmdline': [
+                     'grep -h "test" infile1.txt infile2.txt',
+                     'grep -hv "[abc]" infile1.txt infile2.txt',
+                     'cat infile1.txt infile2.txt | grep "test"',
+                 ],
+                 'shell': True,
+                 'file:infile1.txt': [
+                     'aaaa\ntest1\n',
+                     'bbbb\ntest1\n',
+                     'cccc\ntest1\n',
+                 ],
+                 'file:infile2.txt': [
+                     'aaaa\ntest2\n',
+                     'bbbb\ntest2\n',
+                     'cccc\ntest2\n',
+                 ],
+             },
+             'output': {
+                 'stdout': 'test1\ntest2\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: multiple cmdlines and alt input files as "files"',
+             'input': {
+                 'cmdline': [
+                     'grep -h "test" infile1.txt infile2.txt',
+                     'grep -hv "[abc]" infile1.txt infile2.txt',
+                 ],
+                 'shell': True,
+                 'files': [
+                     {
+                         'infile1.txt': 'aaaa\ntest1\n',
+                         'infile2.txt': 'aaaa\ntest2\n',
+                     },
+                     {
+                         'infile1.txt': '',
+                         'infile2.txt': 'aaaa\ntest1\ntest2\n',
+                     },
+                 ],
+             },
+             'output': {
+                 'stdout': 'test1\ntest2\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: multiple cmdlines and envvars',
+             'input': {
+                 'cmdline': [
+                     'echo "$FOO$SEP$BAR"',
+                     'echo "$FOO-$BAR"',
+                 ],
+                 'shell': True,
+                 'envvars': [
+                     {
+                         'FOO': 'x',
+                         'SEP': '-',
+                         'BAR': 'y',
+                     },
+                     {
+                         'FOO0': 'x',
+                         'FOO': '$FOO0',
+                         'SEP': '-',
+                         'BAR': 'y',
+                     },
+                 ],
+             },
+             'output': {
+                 'stdout': 'x-y\n',
+                 'stderr': '',
+                 'returncode': 0,
+             },
+         },
+         {
+             'name': 'Test: multiple named inputs with multiple alternatives',
+             'input': [
+                 {
+                     'name': 'grep',
+                     'cmdline': [
+                         'grep -h "test" infile1.txt infile2.txt',
+                         'grep -hv "[abc]" infile1.txt infile2.txt',
+                     ],
+                     'shell': True,
+                     'file:infile1.txt': [
+                         'aaaa\ntest1\n',
+                         'bbbb\ntest1\n',
+                     ],
+                     'file:infile2.txt': [
+                         'aaaa\ntest2\n',
+                         'bbbb\ntest2\n',
+                     ],
+                 },
+                 {
+                     'name': 'cat',
+                     'cmdline': [
+                         'cat infile1.txt infile2.txt',
+                         'cat infile3.txt',
+                     ],
+                     'file:infile1.txt': 'test1\n',
+                     'file:infile2.txt': 'test2\n',
+                     'file:infile3.txt': 'test1\ntest2\n',
+                 },
+                 {
+                     'name': 'printf',
+                     'cmdline': [
+                         'printf "test1\\ntest2\\n"',
+                         'printf "test1\ntest2\n"',
+                     ],
+                     'shell': True,
+                 },
+             ],
+             'output': {
+                 'stdout': 'test1\ntest2\n',
                  'stderr': '',
                  'returncode': 0,
              },
@@ -1196,7 +2346,8 @@ def test_collect_testcases(testcase_files, tmpdir):
                     or (isinstance(exp_val, int)
                         and inputitem == 'returncode')
                     or (isinstance(exp_val, list)
-                        and expected['test'] in ['in', 'not-in']))
+                        and expected['test'] in ['in', 'not-in'])
+                    or (exp_val is None and inputitem.startswith('file:')))
             testcase_num += 1
 
 

--- a/vrt-tools/tests/test_scripttestlib.py
+++ b/vrt-tools/tests/test_scripttestlib.py
@@ -533,6 +533,11 @@ _testcase_files_content = [
                          'test': 'python',
                          'value': 'return "test3" not in value',
                      },
+                     {
+                         'name': 'multi-line Python function',
+                         'test': 'python',
+                         'value': 's = "test3"\nreturn s not in value',
+                     },
                  ],
              },
          },
@@ -628,6 +633,11 @@ _testcase_files_content = [
                      {'value': {'python': 'return "test1\\ntest2\\n"'}},
                      {'==': {'python': 'return "test1\\ntest2\\n"'}},
                      {'!=': {'python': 'return "test1\\n"'}},
+                     {
+                         'name': 'multi-line Python function',
+                         'test': '!=',
+                         'value': {'python': 's = "test1"\nreturn s'},
+                     },
                      # Test transformation with value generated with Python
                      {
                          'name': 'transformation with value generated with Python',

--- a/vrt-tools/tests/test_scripttestlib.py
+++ b/vrt-tools/tests/test_scripttestlib.py
@@ -883,6 +883,83 @@ _testcase_files_content = [
              },
          },
          {
+             'name': 'Test: completely replace output file content (implicit set-value)',
+             'input': {
+                 'cmdline': 'cat > file.out',
+                 'shell': True,
+                 'stdin': 'foo\nbar\nbaz\n'
+             },
+             'output': {
+                 'file:file.out': {
+                     'value': 'bar\n',
+                     'transform-expected': 'foo\nbar\nbaz\n',
+                 },
+             },
+         },
+         {
+             'name': 'Test: transform with implicit set-value in list',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': {
+                     'value': '',
+                     'transform-expected': [
+                         'cat: foo: ',
+                         {'append': 'No such file or directory\n'},
+                     ],
+                 },
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': 1,
+                 },
+             },
+         },
+         {
+             'name': 'Test: transform with implicit set-value None',
+             'input': {
+                 'cmdline': 'cat foo bar',
+                 'file:foo': {
+                     'value': 'foo\n',
+                     'transform': [
+                         None,
+                     ],
+                 },
+                 'file:bar': {
+                     'value': '',
+                     'transform': 'bar\n',
+                 },
+             },
+             'output': {
+                 'stdout': {
+                     'value': 'foo\n',
+                     'transform-expected': 'bar\n',
+                 },
+                 'stderr': {
+                     'value': '',
+                     'transform-expected': [
+                         'cat: foo: ',
+                         {'append': 'No such file or directory\n'},
+                     ],
+                 },
+                 'file:foo': {
+                     'value': 'foo\n',
+                     'transform-expected': [
+                         None,
+                     ],
+                 },
+                 'file:bar': {
+                     'value': 'baz\n',
+                     'transform-expected': 'bar\n',
+                 },
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': 1,
+                 },
+             },
+         },
+         {
              'name': 'Test: transform stdin with shell (+ append)',
              'input': {
                  'cmdline': 'cat',
@@ -1274,6 +1351,20 @@ _testcase_files_content = [
              },
          },
          {
+             'name': 'Test: transformations of int: implicit set-value',
+             'input': {
+                 'cmdline': 'cat foo',
+             },
+             'output': {
+                 'stdout': '',
+                 'stderr': 'cat: foo: No such file or directory\n',
+                 'returncode': {
+                     'value': 0,
+                     'transform-expected': 1,
+                 },
+             },
+         },
+         {
              'name': 'Test: transformations of int: keep intact',
              'input': {
                  'cmdline': 'cat foo',
@@ -1290,6 +1381,9 @@ _testcase_files_content = [
                          {'replace': '/3/4/'},
                          {'set-value': 'foo'},
                          {'set-value': None},
+                         # Implicit set-value
+                         'bar',
+                         None,
                      ],
                  },
              },
@@ -1802,6 +1896,16 @@ _testcase_files_content = [
                          }
                      },
                  },
+                 # Implicit set-value
+                 {
+                     'input': {
+                         'cmdline': 'cat input.txt input2.txt',
+                     },
+                     'output-expected': {
+                         'stderr': 'cat: input2.txt: No such file or directory\n',
+                         'returncode': 1,
+                     },
+                 },
              ],
          },
          {
@@ -1947,6 +2051,45 @@ _testcase_files_content = [
                      },
                  },
                  {
+                     'input': {
+                         'stdin': {
+                             'append': 'xxx\n',
+                         },
+                     },
+                     'output-actual': {
+                         'stdout': {
+                             'filter-out': 'xxx\n',
+                         },
+                     },
+                 },
+             ],
+         },
+         {
+             'name': 'Test: transformation group names',
+             'input': {
+                 'cmdline': 'cat',
+                 'stdin': 'foo\nbar\nbaz\n',
+             },
+             'output': {
+                 'stdout': 'foo\nbar\nbaz\n',
+             },
+             'transform': [
+                 {},  # No transformations
+                 {
+                     'name': 'trans 1',
+                     'input': {
+                         'stdin': {
+                             'replace': '/\n/yyy\n/',
+                         },
+                     },
+                     'output-expected': {
+                         'stdout': {
+                             'replace': '/\n/yyy\n/',
+                         },
+                     },
+                 },
+                 {
+                     'name': 'trans 2',
                      'input': {
                          'stdin': {
                              'append': 'xxx\n',


### PR DESCRIPTION
## New features

These changes extend in several ways the VRT Tool [`vrt-add-id`](../blob/50284da0/vrt-tools/vrt-add-id) (or rather its library implementation [`libvrt.tools.vrt_add_id`](../blob/50284da0/vrt-tools/libvrt/tools/vrt_add_id.py)):

1. Generate unique random ids (with a specified maximum value) as an alternative to an incrementing sequence.
2. Format ids using Python `str.format`-style formatting.
3. Add ids to multiple types of element (structures) on a single run.
4. Include in ids hex digests of SHA-1 hashes of constant strings.
5. Rename existing attributes with the name of the id attribute, as an alternative to overwriting.

The modified version is backward-compatible with the original one, _except_ that element attributes are _not_ sorted by default but only with option `--sort`.

## Usage

A typical use of `vrt-add-id` for adding random ids to texts, paragraphs and sentences, prefixed with a prefix of the SHA-1 hash of the corpus id could be as follows:

```bash
vrt-add-id --rename --hash=corpus_id --type=random \
  --element=text --format="t-{hash:.6}-{id:08x}" \
  --element=paragraph --format="p-{hash:.6}-{idnum[text]:08x}-{id:08x}" \
  --element=sentence --format="s-{hash:.6}-{idnum[text]:08x}-{id:08x}" \
  input.vrt > output.vrt
```

The usage message is now the following (skipping the common VRT Tools file options):

```
usage: vrt-add-id [-h] [--out file | --in-place | --backup bak | --in-sibling EXT] [--version]
                  [--hash string] [--force] [--sort] [--no-optimize] [--verbose]
                  [--element name] [--id name] [--type {counter,random}] [--seed string]
                  [--start number] [--end number] [--format format] [--prefix affix]
                  [--rename [name]]
                  [file]

Add or overwrite an "id" attribute to each element of the specified kind, based on a counter or
unique random values.

positional arguments:
  file                  input file (default stdin)

options:
  -h, --help            show this help message and exit
  --out file, -o file   output file (default stdout)
  --in-place, -i        replace input file with final output
  --backup bak, -b bak  replace input file with final output, keep input file with the added
                        suffix bak
  --in-sibling EXT, -I EXT
                        write to a sibling file, adding .EXT to the input file name, or
                        replacing .OLD with .NEW when EXT is OLD/NEW (allow ASCII letters,
                        digits, underscore, hyphen, and separating period)
  --version             show program's version number and exit
  --hash string         make "{hash}" in the id format string refer to the hex digest of the
                        SHA-1 hash of string; if the option is repeated, "{hashN}" refers to
                        the Nth value
  --force               overwriting an existing id
  --sort                sort element attributes alphabetically (default: keep input order)
  --no-optimize         use the slower method even if the faster one could be used (see below)
  --verbose             output to stderr the method used and the number of ids added
  --element name        name of the VRT element to use; can be repeated; if no --element is
                        specified, use "sentence"

element-specific options:
  The following options can be specified multiple times: each occurrence applies to the
  --element after which it is specified. If an option is specified before any --element, it
  becomes the default for all elements.

  --id name             name of the "id" attribute ("id")
  --type {counter,random}
                        type of id values: "counter" for integers based on a counter, "random"
                        for unique random integers ("counter")
  --seed string         random number generator seed for random ids; if specified before any
                        --element, the element name is included in the seed, producing a
                        different seed for each element type; to use the same seed for multiple
                        element types, specify it explicitly after each --element; if string
                        begins with "<", the rest is the name of the file whose content (up to
                        1 MiB) to use as the seed (default: "" = non-reproducible)
  --start number        initial value for the counter (1)
  --end number          maximum random id value is number - 1; a non-negative integer,
                        hexadecimal if prefixed with "0x", or n^k for n to the power of k
                        (default: 2^32)
  --format format       format string for id, with Python str.format-style formatting: "{id}"
                        is replaced with the integer id value, "{idnum[elem]}" with the integer
                        id value for element elem, and "{elem[attr]}" with the string value of
                        the existing attribute attr in the current or an enclosing element (the
                        current element can also be referred to as "this"); formatting string
                        values is extended with regular expression substitutions:
                        "{elem[attr]/regexp/subst/}" is "{elem[attr]}" with all matches of
                        regexp replaced with subst; subst may refer to groups in regexp as \N,
                        \g<N> or \g<name>; multiple substitutions are separated by commas,
                        semicolons or spaces (default: with --type=counter, "{id}"; with
                        --type=random, "{id:0*x}" where * is the minimum number of hex digits
                        to represent the maximum value)
  --prefix affix        additional prefix text to each formatted id, prepended to the format
                        string specified with --format ("")
  --rename [name]       rename possible existing id attribute to name; name may contain "{}" to
                        be replaced with the original name; if also the renamed attribute
                        already exists, append to the name "_N" where N is the smallest
                        positive integer for which the resulting attribute does not exist; if
                        name is omitted, "{}_orig" is used

The program contains two alternative methods of adding id attributes: a slower one with more
features and a faster one with fewer features. The slower one is used in following cases: (1)
with one or more of the options --no-optimize, --force, --sort and --rename; (2) if an id
format refers to other replacement fields than {id}, {idnum[elem]}, {hash} and {hashN}; (3) if
{id} or {idnum[elem]} for a certain element occurs with several different format
specifications; or (4) if a format specification does not match the regular expression
"[0-9]*[dxX]?".
```

## Library additions

Changes also include some additions to `vrtlib` library modules:

- [`libvrt.metaline`](../blob/50284da0/vrt-tools/libvrt/metaline.py):
  - New functions `element`, `ismeta`, `isstarttag`, `isendtag`, `iscomment` and the corresponding versions for strings (with prefix `str`).
  - Functions `starttag` and `strstarttag` can sort the attributes or use the existing order (default).
- [`libvrt.strformatters`](../blob/50284da0/vrt-tools/libvrt/strformatters.py): New module containing `string.Formatter` subclasses:
  - `PartialFormatter`: Use a fixed value or keep intact replacement fields with missing values.
  - `BytesFormatter`: Convert `bytes` values in replacement values and `dict` keys to `str`.
  - `SubstitutingFormatter`: Allow regular expression substitutions in replacement values: `{key/regexp/subst}`.
- [`libvrt.groupargs`](../blob/50284da0/vrt-tools/libvrt/groupargs.py): New module implementing “grouped command-line arguments” by defining `argparse.Action` subclasses: one option argument is defined as a *grouping argument* and some other arguments as *grouped arguments*. The values of grouped arguments are attached to the preceding value of the grouping argument. In `vrt-add-id`, `--element` is a grouping argument.

## Tests

`vrt-add-id` has [`scripttestlib` tests in YAML](../blob/50284da0/vrt-tools/tests/scripttests/scripttest_vrt_add_id.yaml), and the additions to libraries [normal Pytest tests](../tree/50284da0/vrt-tools/tests/libvrt).

Some new features used by the tests were added to the [`scripttestlib` library](../blob/50284da0/vrt-tools/tests/scripttestlib.py).

## Performance

A drawback of the new features is that `vrt-add-id` is significantly slower than before. I thus implemented an optimized method for the typical case in which we will probably use the script (see the typical usage above): adding text and sentence (and paragraph) ids on one run, with sentence (and paragraph) ids referring to text ids, id appended as the last attribute of the start tag (not sorted) and assuming that no attribute with the same name already exists. The optimized version lacks many of the added features but it is used whenever possible, unless the option `--no-optimize` is specified.

I tested the old and new `vrt-add-id` as well as my legacy shell + Perl script [`vrt-add-struct-ids.sh`](../blob/6cf6ba22/scripts/vrt-add-struct-ids.sh) on the final `klk_fi_v2_2014` VRT file (4.2 GiB, 41,694,782 tokens, 28,413 texts, 4,622,425 sentences). (real times in seconds of a single run on an interactive SLURM session on Puhti):

| Task | [`vrt-add-struct-ids.sh`](../blob/6cf6ba22/scripts/vrt-add-struct-ids.sh) | [Old `vrt-add-id`](../blob/6cf6ba22/vrt-tools/libvrt/tools/vrt_add_id.py) | [New `vrt-add-id`](../blob/50284da0/vrt-tools/libvrt/tools/vrt_add_id.py) | [New `vrt-add-id`](../blob/50284da0/vrt-tools/libvrt/tools/vrt_add_id.py) optimized |
| --- | --- | --- | --- | --- |
| Add new counter id (with prefix) to sentences | 25 | 49 | 85 | 28 |
| Add new counter id (with prefix) to texts | 19 | 18 | 47 | 23 |
| Add new formatted random id to sentences | – | – | 103 | 35 | 
| Add new formatted random id to texts | – | – | 48 | 23 |
| Add new formatted random ids to texts and sentences | – | – | 144 | 36 |

The non-optimized method in the new version seems to spend 2 to 2.5 times as much time as the old one, whereas the optimized one is in some cases even faster than the old one.
