### PR TITLE
`vrt-scramble`: Scramble VRT input

### DIFF
--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -1,0 +1,123 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+"""Scramble (randomly shuffle) structures in a VRT input."""
+
+
+# This script has been converted from Python 2 to Python 3.
+
+# TODO:
+# - Rewrite the script as a proper VRT tool.
+
+
+import sys
+import re
+import random
+
+from math import floor
+
+import korpimport3.util
+
+
+class VrtScrambler(korpimport3.util.InputProcessor):
+
+    def __init__(self):
+        super().__init__()
+        self._scramble_units = []
+        # version=1 to be compatible with Python 2 random
+        random.seed(self._opts.random_seed, version=1)
+
+    def process_input_stream(self, stream, filename=None):
+        within_begin_re = re.compile(
+            r'<' + self._opts.scramble_within + '[>\s]')
+        scramble_begin_re = re.compile(
+            r'<' + self._opts.scramble_unit + '[>\s]')
+        scramble_end = '</' + self._opts.scramble_within + '>'
+        collecting = False
+        units = []
+        current_unit = []
+        for line in stream:
+            self._linenr += 1
+            if collecting:
+                if line.startswith(scramble_end):
+                    if current_unit:
+                        units.append(current_unit)
+                    collecting = False
+                    for line2 in self._scramble(units):
+                        sys.stdout.write(line2)
+                    sys.stdout.write(line)
+                elif scramble_begin_re.match(line):
+                    if current_unit:
+                        units.append(current_unit)
+                    current_unit = [line]
+                elif line.startswith('<') and current_unit == []:
+                    mo = re.match(r'<([a-z_0-9]+)', line)
+                    struct = ''
+                    if mo:
+                        struct = mo.group(1)
+                    self.error('Structure \'' + struct + '\' between \''
+                               + self._opts.scramble_within + '\' and \''
+                               + self._opts.scramble_unit + '\'')
+                else:
+                    current_unit.append(line)
+            else:
+                sys.stdout.write(line)
+                if within_begin_re.match(line):
+                    units = []
+                    current_unit = []
+                    collecting = True
+
+    def _scramble(self, units):
+        self._random_shuffle(units)
+        for unit in units:
+            for line in unit:
+                yield line
+
+    def _random_shuffle(self, seq):
+        """Randomly shuffle seq, same results as Python 2 random.shuffle."""
+        # This code was copied from the Python 3.10 library code for
+        # random.shuffle. Up to Python 3.10, the same result could be
+        # achieved by using random.shuffle(seq, random=random.random),
+        # but the parameter random will be removed in Python 3.11
+        # (deprecated in 3.9).
+        for i in reversed(range(1, len(seq))):
+            # pick an element in seq[:i+1] with which to exchange seq[i]
+            j = floor(random.random() * (i + 1))
+            seq[i], seq[j] = seq[j], seq[i]
+
+    def getopts(self, args=None):
+        self.getopts_basic(
+            dict(usage="%prog [options] [input] > output",
+                 description=(
+"""Scramble (randomly shuffle) given structures (elements), such as sentences,
+within larger structures, such as texts, in the VRT input and output the
+scrambled VRT.
+
+Note that the input may not have intermediate structures between the
+containing structures and the structures to be scrambled; for example, if
+sentences are scrambled within texts, the input may not have paragraphs.
+""")
+             ),
+            args,
+            ['scramble-unit|unit =STRUCT', dict(
+                default='sentence',
+                help=('shuffle STRUCT structures (elements)'
+                      ' (default: %default)'))],
+            ['scramble-within|within =STRUCT', dict(
+                default='text',
+                help=('shuffle structures within STRUCT structures (elements):'
+                      ' structures are not moved across STRUCT boundaries'
+                      ' (default: %default)'))],
+            ['random-seed|seed =SEED', dict(
+                default='2017',
+                help=('set random number generator seed to SEED (any string);'
+                      ' use 0 or "" for a random seed (non-reproducible'
+                      ' output) (default: %default)'))],
+        )
+        if self._opts.random_seed in ['', '0']:
+            self._opts.random_seed = None
+
+
+if __name__ == "__main__":
+    VrtScrambler().run()

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -22,14 +22,14 @@ class VrtScrambler(InputProcessor):
     """Class implementing vrt-scramble functionality."""
 
     DESCRIPTION = """
-    Scramble (randomly shuffle) given structures (elements), such as
-    sentences, within larger structures, such as texts, in the VRT
-    input and output the scrambled VRT.
+    Scramble the input VRT by randomly shuffling specified structures
+    (elements), such as sentences, within containing structures, such
+    as texts, and output the scrambled VRT.
 
     Note that the input may not have intermediate structures between
-    the containing structures and the structures to be scrambled; for
-    example, if sentences are scrambled within texts, the input may
-    not have paragraphs.
+    the containing structures and the structures to be shuffled; for
+    example, if sentences are shuffled within texts, the input may
+    not have paragraphs between them.
     """
     ARGSPECS = [
         ('--unit = struct "sentence"',
@@ -38,7 +38,7 @@ class VrtScrambler(InputProcessor):
          '''shuffle structures within struct structures (elements):
             structures are not moved across struct boundaries'''),
         ('--seed = string',
-         '''set random number generator seed to string; if string
+         '''use string as the random number generator seed; if string
             begins with "<", the rest is the name of the file whose
             content (up to 1 MiB) to use as the seed (default: "" =
             non-reproducible output)''',

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -37,9 +37,10 @@ class VrtScrambler(InputProcessor):
         ('--within = struct "text"',
          '''shuffle structures within struct structures (elements):
             structures are not moved across struct boundaries'''),
-        ('--seed = seed "2017"',
-         '''set random number generator seed to seed (any string);
-            use 0 or "" for a random seed (non-reproducible output)'''),
+        ('--seed = seed',
+         '''set random number generator seed to seed (any string)
+            (default: "" = non-reproducible output)''',
+         dict(default='')),
     ]
 
     class OPTIONS(InputProcessor.OPTIONS):
@@ -51,7 +52,7 @@ class VrtScrambler(InputProcessor):
         self._scramble_units = []
 
     def check_args(self, args):
-        if args.seed in ['', '0']:
+        if args.seed == '':
             args.seed = None
 
     def main(self, args, inf, ouf):

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -43,10 +43,6 @@ class VrtScrambler(InputProcessor):
          dict(default='')),
     ]
 
-    class OPTIONS(InputProcessor.OPTIONS):
-        in_as_text = True
-        out_as_text = True
-
     def __init__(self):
         super().__init__()
         self._scramble_units = []
@@ -59,10 +55,10 @@ class VrtScrambler(InputProcessor):
         # version=1 to be compatible with Python 2 random
         random.seed(args.seed, version=1)
         within_begin_re = re.compile(
-            r'<' + args.within + '[>\s]')
+            (r'<' + args.within + '[>\s]').encode('UTF-8'))
         scramble_begin_re = re.compile(
-            r'<' + args.unit + '[>\s]')
-        scramble_end = '</' + args.within + '>'
+            (r'<' + args.unit + '[>\s]').encode('UTF-8'))
+        scramble_end = ('</' + args.within + '>').encode('UTF-8')
         collecting = False
         units = []
         current_unit = []
@@ -81,12 +77,13 @@ class VrtScrambler(InputProcessor):
                     if current_unit:
                         units.append(current_unit)
                     current_unit = [line]
-                elif line.startswith('<') and current_unit == []:
-                    mo = re.match(r'<([a-z_0-9]+)', line)
+                elif line.startswith(b'<') and current_unit == []:
+                    mo = re.match(br'<([a-z_0-9]+)', line)
                     struct = ''
                     if mo:
                         struct = mo.group(1)
-                    self.error_exit('Structure \'' + struct + '\' between \''
+                    self.error_exit('Structure \'' + struct.decode('UTF-8')
+                                    + '\' between \''
                                     + args.within + '\' and \''
                                     + args.unit + '\'')
                 else:

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -93,6 +93,7 @@ class VrtScrambler(InputProcessor):
         within_begin = make_starttag_begin(args.within)
         unit_begin = make_starttag_begin(args.unit)
         within_end = b'</' + args.within.encode('UTF-8') + b'>'
+        unit_end = b'</' + args.unit.encode('UTF-8') + b'>'
         collecting = False
         units = []
         current_unit = []
@@ -105,6 +106,11 @@ class VrtScrambler(InputProcessor):
                         if current_unit:
                             units.append(current_unit)
                         current_unit = [line]
+                    elif line.startswith(unit_end):
+                        # End of scramble unit: add to collected units
+                        current_unit.append(line)
+                        units.append(current_unit)
+                        current_unit = []
                     elif line.startswith(within_end):
                         if current_unit:
                             units.append(current_unit)

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -121,6 +121,15 @@ class VrtScrambler(InputProcessor):
                                 + f'\' between \'{args.within}\' and'
                                 + f' \'{args.unit}\'',
                                 filename=inf.name, linenr=linenr)
+                        elif units:
+                            # Append comment lines following the end
+                            # tag of a unit structure to the preceding
+                            # unit
+                            units[-1].append(line)
+                        else:
+                            # Output comment lines directly after the
+                            # start of within
+                            ouf.write(line)
                     else:
                         current_unit.append(line)
                 else:

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -119,8 +119,11 @@ class VrtScrambler(InputProcessor):
                             ouf.write(line2)
                         ouf.write(line)
                     elif current_unit == []:
-                        mo = re.match(br'<([a-z_0-9]+)', line)
+                        # Outside scramble units but within the
+                        # structure within which units are scrambled
+                        mo = re.match(br'</?([a-z_0-9]+)', line)
                         if mo:
+                            # No structure tags allowed here
                             struct = mo.group(1)
                             self.error_exit(
                                 'Structure \'' + struct.decode('UTF-8')

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -69,9 +69,9 @@ class VrtScrambler(InputProcessor):
         collecting = False
         units = []
         current_unit = []
-        self._linenr = 0
+        linenr = 0
         for line in inf:
-            self._linenr += 1
+            linenr += 1
             if collecting:
                 if line.startswith(scramble_end):
                     if current_unit:
@@ -89,10 +89,10 @@ class VrtScrambler(InputProcessor):
                     struct = ''
                     if mo:
                         struct = mo.group(1)
-                    self.error_exit('Structure \'' + struct.decode('UTF-8')
-                                    + '\' between \''
-                                    + args.within + '\' and \''
-                                    + args.unit + '\'')
+                    self.error_exit(
+                        'Structure \'' + struct.decode('UTF-8')
+                        + f'\' between \'{args.within}\' and \'{args.unit}\'',
+                        filename=inf.name, linenr=linenr)
                 else:
                     current_unit.append(line)
             else:

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -149,9 +149,9 @@ class VrtScrambler(InputProcessor):
                             # No structure tags allowed here
                             struct = mo.group(1)
                             self.error_exit(
-                                'Structure \'' + struct.decode('UTF-8')
-                                + f'\' between \'{args.within}\' and'
-                                + f' \'{args.unit}\'',
+                                f"Structure '{struct.decode('UTF-8')}' not"
+                                f" allowed between container '{args.within}'"
+                                f" and shuffle item '{args.unit}'",
                                 filename=inf.name, linenr=linenr)
                         elif items:
                             # Append comment lines following the end

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -32,12 +32,12 @@ class VrtScrambler(InputProcessor):
     not have paragraphs.
     """
     ARGSPECS = [
-        ('--scramble-unit|unit = struct "sentence"',
+        ('--unit = struct "sentence"',
          '''shuffle struct structures (elements)'''),
-        ('--scramble-within|within = struct "text"',
+        ('--within = struct "text"',
          '''shuffle structures within struct structures (elements):
             structures are not moved across struct boundaries'''),
-        ('--random-seed|seed = seed "2017"',
+        ('--seed = seed "2017"',
          '''set random number generator seed to seed (any string);
             use 0 or "" for a random seed (non-reproducible output)'''),
     ]
@@ -51,17 +51,17 @@ class VrtScrambler(InputProcessor):
         self._scramble_units = []
 
     def check_args(self, args):
-        if args.random_seed in ['', '0']:
-            args.random_seed = None
+        if args.seed in ['', '0']:
+            args.seed = None
 
     def main(self, args, inf, ouf):
         # version=1 to be compatible with Python 2 random
-        random.seed(args.random_seed, version=1)
+        random.seed(args.seed, version=1)
         within_begin_re = re.compile(
-            r'<' + args.scramble_within + '[>\s]')
+            r'<' + args.within + '[>\s]')
         scramble_begin_re = re.compile(
-            r'<' + args.scramble_unit + '[>\s]')
-        scramble_end = '</' + args.scramble_within + '>'
+            r'<' + args.unit + '[>\s]')
+        scramble_end = '</' + args.within + '>'
         collecting = False
         units = []
         current_unit = []
@@ -86,8 +86,8 @@ class VrtScrambler(InputProcessor):
                     if mo:
                         struct = mo.group(1)
                     self.error_exit('Structure \'' + struct + '\' between \''
-                                    + args.scramble_within + '\' and \''
-                                    + args.scramble_unit + '\'')
+                                    + args.within + '\' and \''
+                                    + args.unit + '\'')
                 else:
                     current_unit.append(line)
             else:

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -41,6 +41,9 @@ class VrtScrambler(InputProcessor):
          '''set random number generator seed to seed (any string)
             (default: "" = non-reproducible output)''',
          dict(default='')),
+        ('--legacy',
+         '''produce the same result as the old vrt-scramble.py for any
+            non-empty seed'''),
     ]
 
     def __init__(self):
@@ -52,8 +55,13 @@ class VrtScrambler(InputProcessor):
             args.seed = None
 
     def main(self, args, inf, ouf):
-        # version=1 to be compatible with Python 2 random
-        random.seed(args.seed, version=1)
+        if args.legacy:
+            seed_ver = 1
+            self._random_shuffle = self._random_shuffle_legacy
+        else:
+            seed_ver = 2
+            self._random_shuffle = random.shuffle
+        random.seed(args.seed, version=seed_ver)
         within_begin_re = re.compile(
             (r'<' + args.within + '[>\s]').encode('UTF-8'))
         scramble_begin_re = re.compile(
@@ -101,7 +109,7 @@ class VrtScrambler(InputProcessor):
             for line in unit:
                 yield line
 
-    def _random_shuffle(self, seq):
+    def _random_shuffle_legacy(self, seq):
         """Randomly shuffle seq, same results as Python 2 random.shuffle."""
         # This code was copied from the Python 3.10 library code for
         # random.shuffle. Up to Python 3.10, the same result could be

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -48,7 +48,6 @@ class VrtScrambler(InputProcessor):
 
     def __init__(self):
         super().__init__()
-        self._scramble_units = []
 
     def check_args(self, args):
         if args.seed == '':

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -29,7 +29,7 @@ class VrtScrambler(InputProcessor):
     Note that the input may not have intermediate structures between
     the containing structures and the structures to be shuffled; for
     example, if sentences are shuffled within texts, the input may
-    not have paragraphs between them.
+    not have paragraphs between texts and sentences.
     """
     ARGSPECS = [
         ('--unit = struct "sentence"',

--- a/vrt-tools/libvrt/tools/vrt_scramble.py
+++ b/vrt-tools/libvrt/tools/vrt_scramble.py
@@ -55,6 +55,12 @@ class VrtScrambler(InputProcessor):
         super().__init__()
 
     def check_args(self, args):
+        """Check and modify args (args.seed)."""
+        # Scramble unit and within may not be the same
+        if args.within == args.unit:
+            self.error_exit(
+                'The structure to scramble and the containing structure may'
+                ' not be the same')
         if not args.seed:
             args.seed = None
         elif args.seed[0] == '<':

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -98,25 +98,25 @@
       <sentence n="3">
       c
       </sentence>
+      <sentence n="1">
+      a
+      </sentence>
       <sentence n="2">
       b
       </sentence>
       <sentence n="4">
       d
       </sentence>
-      <sentence n="1">
-      a
-      </sentence>
       </paragraph>
       <paragraph n="2">
-      <sentence n="7">
-      g
+      <sentence n="6">
+      f
       </sentence>
       <sentence n="5">
       e
       </sentence>
-      <sentence n="6">
-      f
+      <sentence n="7">
+      g
       </sentence>
       </paragraph>
       <paragraph n="3">
@@ -130,28 +130,96 @@
       </text>
       <text n="2">
       <paragraph n="4">
-      <sentence n="11">
-      k
-      </sentence>
       <sentence n="10">
       j
       </sentence>
       <sentence n="12">
       l
       </sentence>
+      <sentence n="11">
+      k
+      </sentence>
       </paragraph>
       <paragraph n="5">
+      <sentence n="14">
+      n
+      </sentence>
       <sentence n="15">
       o
       </sentence>
       <sentence n="13">
       m
       </sentence>
-      <sentence n="14">
-      n
-      </sentence>
       </paragraph>
       </text>
+  transform:
+  - {}
+  - name: --legacy
+    input: &cmdline-legacy
+      cmdline:
+        append: ' --legacy'
+    output-expected:
+      stdout: |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1">
+        <paragraph n="1">
+        <sentence n="3">
+        c
+        </sentence>
+        <sentence n="2">
+        b
+        </sentence>
+        <sentence n="4">
+        d
+        </sentence>
+        <sentence n="1">
+        a
+        </sentence>
+        </paragraph>
+        <paragraph n="2">
+        <sentence n="7">
+        g
+        </sentence>
+        <sentence n="5">
+        e
+        </sentence>
+        <sentence n="6">
+        f
+        </sentence>
+        </paragraph>
+        <paragraph n="3">
+        <sentence n="8">
+        h
+        </sentence>
+        <sentence n="9">
+        i
+        </sentence>
+        </paragraph>
+        </text>
+        <text n="2">
+        <paragraph n="4">
+        <sentence n="11">
+        k
+        </sentence>
+        <sentence n="10">
+        j
+        </sentence>
+        <sentence n="12">
+        l
+        </sentence>
+        </paragraph>
+        <paragraph n="5">
+        <sentence n="15">
+        o
+        </sentence>
+        <sentence n="13">
+        m
+        </sentence>
+        <sentence n="14">
+        n
+        </sentence>
+        </paragraph>
+        </text>
 
 
 - name: 'vrt-scramble: Paragraphs within texts'
@@ -164,25 +232,6 @@
     stdout: |
       <!-- #vrt positional-attributes: word -->
       <text n="1">
-      <paragraph n="2">
-      <sentence n="5">
-      e
-      </sentence>
-      <sentence n="6">
-      f
-      </sentence>
-      <sentence n="7">
-      g
-      </sentence>
-      </paragraph>
-      <paragraph n="3">
-      <sentence n="8">
-      h
-      </sentence>
-      <sentence n="9">
-      i
-      </sentence>
-      </paragraph>
       <paragraph n="1">
       <sentence n="1">
       a
@@ -197,19 +246,27 @@
       d
       </sentence>
       </paragraph>
-      </text>
-      <text n="2">
-      <paragraph n="4">
-      <sentence n="10">
-      j
+      <paragraph n="3">
+      <sentence n="8">
+      h
       </sentence>
-      <sentence n="11">
-      k
-      </sentence>
-      <sentence n="12">
-      l
+      <sentence n="9">
+      i
       </sentence>
       </paragraph>
+      <paragraph n="2">
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="7">
+      g
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
       <paragraph n="5">
       <sentence n="13">
       m
@@ -221,7 +278,84 @@
       o
       </sentence>
       </paragraph>
+      <paragraph n="4">
+      <sentence n="10">
+      j
+      </sentence>
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      </paragraph>
       </text>
+  transform:
+  - {}
+  - name: --legacy
+    input: *cmdline-legacy
+    output-expected:
+      stdout: |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1">
+        <paragraph n="2">
+        <sentence n="5">
+        e
+        </sentence>
+        <sentence n="6">
+        f
+        </sentence>
+        <sentence n="7">
+        g
+        </sentence>
+        </paragraph>
+        <paragraph n="3">
+        <sentence n="8">
+        h
+        </sentence>
+        <sentence n="9">
+        i
+        </sentence>
+        </paragraph>
+        <paragraph n="1">
+        <sentence n="1">
+        a
+        </sentence>
+        <sentence n="2">
+        b
+        </sentence>
+        <sentence n="3">
+        c
+        </sentence>
+        <sentence n="4">
+        d
+        </sentence>
+        </paragraph>
+        </text>
+        <text n="2">
+        <paragraph n="4">
+        <sentence n="10">
+        j
+        </sentence>
+        <sentence n="11">
+        k
+        </sentence>
+        <sentence n="12">
+        l
+        </sentence>
+        </paragraph>
+        <paragraph n="5">
+        <sentence n="13">
+        m
+        </sentence>
+        <sentence n="14">
+        n
+        </sentence>
+        <sentence n="15">
+        o
+        </sentence>
+        </paragraph>
+        </text>
 
 
 - name: 'vrt-scramble: Sentences within texts'
@@ -240,8 +374,11 @@
       <sentence n="5">
       e
       </sentence>
-      <sentence n="9">
-      i
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="2">
+      b
       </sentence>
       <sentence n="4">
       d
@@ -249,42 +386,95 @@
       <sentence n="7">
       g
       </sentence>
-      <sentence n="2">
-      b
-      </sentence>
-      <sentence n="8">
-      h
-      </sentence>
       <sentence n="6">
       f
       </sentence>
-      <sentence n="3">
-      c
-      </sentence>
       <sentence n="1">
       a
+      </sentence>
+      <sentence n="9">
+      i
+      </sentence>
+      <sentence n="8">
+      h
       </sentence>
       </text>
       <text n="2">
       <sentence n="11">
       k
       </sentence>
-      <sentence n="15">
-      o
-      </sentence>
       <sentence n="13">
       m
-      </sentence>
-      <sentence n="14">
-      n
-      </sentence>
-      <sentence n="10">
-      j
       </sentence>
       <sentence n="12">
       l
       </sentence>
+      <sentence n="14">
+      n
+      </sentence>
+      <sentence n="15">
+      o
+      </sentence>
+      <sentence n="10">
+      j
+      </sentence>
       </text>
+  transform:
+  - {}
+  - name: --legacy
+    input: *cmdline-legacy
+    output-expected:
+      stdout: |
+        <!-- #vrt positional-attributes: word -->
+        <text n="1">
+        <sentence n="5">
+        e
+        </sentence>
+        <sentence n="9">
+        i
+        </sentence>
+        <sentence n="4">
+        d
+        </sentence>
+        <sentence n="7">
+        g
+        </sentence>
+        <sentence n="2">
+        b
+        </sentence>
+        <sentence n="8">
+        h
+        </sentence>
+        <sentence n="6">
+        f
+        </sentence>
+        <sentence n="3">
+        c
+        </sentence>
+        <sentence n="1">
+        a
+        </sentence>
+        </text>
+        <text n="2">
+        <sentence n="11">
+        k
+        </sentence>
+        <sentence n="15">
+        o
+        </sentence>
+        <sentence n="13">
+        m
+        </sentence>
+        <sentence n="14">
+        n
+        </sentence>
+        <sentence n="10">
+        j
+        </sentence>
+        <sentence n="12">
+        l
+        </sentence>
+        </text>
 
 
 - name: 'vrt-scramble: Sentences within texts, infile as argument, --out'
@@ -347,3 +537,9 @@
     file:out1.vrt:
       '!=':
         file: out2.vrt
+  transform:
+  - {}
+  - name: --legacy
+    input:
+      cmdline:
+        replace: '/--seed/--legacy --seed/'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -776,3 +776,43 @@
     stderr: |
       vrt-scramble: <stdin>:12: Structure 'paragraph' between 'text' and 'sentence'
     returncode: 1
+
+- name: 'vrt-scramble: Other structure end tag between within and unit'
+  input:
+    cmdline: vrt-scramble --within=paragraph --unit=sentence --seed=1
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <bold n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="2">
+      b
+      </sentence>
+      </bold>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <bold n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+    stderr: |
+      vrt-scramble: <stdin>:13: Structure 'bold' between 'paragraph' and 'sentence'
+    returncode: 1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -816,3 +816,14 @@
     stderr: |
       vrt-scramble: <stdin>:13: Structure 'bold' between 'paragraph' and 'sentence'
     returncode: 1
+
+
+- name: 'vrt-scramble: Unit the same as within'
+  input:
+    cmdline: vrt-scramble --within=sentence --unit=sentence --seed=1
+    stdin: *input-ts
+  output:
+    stdout: ''
+    stderr: |
+      vrt-scramble: The structure to scramble and the containing structure may not be the same
+    returncode: 1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -662,3 +662,81 @@
     stderr: |
       vrt-scramble: Cannot read random seed from file seed.txt: [Errno 2] No such file or directory: 'seed.txt'
     returncode: 1
+
+
+- name: 'vrt-scramble: Comments within structures to be scrambled'
+  input:
+    cmdline: vrt-scramble --within=text --unit=sentence --seed=1
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <!-- Comment before text start tag 1 -->
+      <text n="1">
+      <!-- Comment after text start tag 1 -->
+      <!-- Comment 2 after text start tag 1 -->
+      <sentence n="1">
+      <!-- Comment after sentence start tag 1 -->
+      a
+      <!-- Comment before sentence end tag 1 -->
+      </sentence>
+      <!-- Comment between sentences 1 and 2 -->
+      <sentence n="2">
+      b
+      </sentence>
+      <!-- Comment between sentences 2 and 3 -->
+      <sentence n="3">
+      c
+      </sentence>
+      <!-- Comment between sentences 3 and 4 -->
+      <sentence n="4">
+      d
+      </sentence>
+      <!-- Comment after sentence 4 ->
+      </text>
+      <!-- Comment between texts 1 and 2 -->
+      <text n="2">
+      <!-- Comment after text start tag 2 -->
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      </text>
+      <!-- Comment after text end tag 2 -->
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <!-- Comment before text start tag 1 -->
+      <text n="1">
+      <!-- Comment after text start tag 1 -->
+      <!-- Comment 2 after text start tag 1 -->
+      <sentence n="3">
+      c
+      </sentence>
+      <!-- Comment between sentences 3 and 4 -->
+      <sentence n="1">
+      <!-- Comment after sentence start tag 1 -->
+      a
+      <!-- Comment before sentence end tag 1 -->
+      </sentence>
+      <!-- Comment between sentences 1 and 2 -->
+      <sentence n="2">
+      b
+      </sentence>
+      <!-- Comment between sentences 2 and 3 -->
+      <sentence n="4">
+      d
+      </sentence>
+      <!-- Comment after sentence 4 ->
+      </text>
+      <!-- Comment between texts 1 and 2 -->
+      <text n="2">
+      <!-- Comment after text start tag 2 -->
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="5">
+      e
+      </sentence>
+      </text>
+      <!-- Comment after text end tag 2 -->

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -740,3 +740,39 @@
       </sentence>
       </text>
       <!-- Comment after text end tag 2 -->
+
+
+- name: 'vrt-scramble: Other structure between within and unit, not starting at the beginning of within'
+  input:
+    cmdline: vrt-scramble --within=text --unit=sentence --seed=1
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence n="1">
+      a
+      <clause>
+      a1
+      </clause>
+      <clause>
+      a2
+      </clause>
+      </sentence>
+      <paragraph n="1">
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+    stderr: |
+      vrt-scramble: <stdin>:12: Structure 'paragraph' between 'text' and 'sentence'
+    returncode: 1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -1,0 +1,349 @@
+
+# scripttestlib tests for vrt-add-id
+
+
+# Default input and output
+
+- defaults:
+    output:
+      # No errors
+      returncode: 0
+      stderr: ''
+
+
+- name: 'vrt-scramble: Default options'
+  input:
+    cmdline: vrt-scramble
+    stdin: &input-1 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="7">
+      g
+      </sentence>
+      </paragraph>
+      <paragraph n="3">
+      <sentence n="8">
+      h
+      </sentence>
+      <sentence n="9">
+      i
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="4">
+      <sentence n="10">
+      j
+      </sentence>
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      </paragraph>
+      <paragraph n="5">
+      <sentence n="13">
+      m
+      </sentence>
+      <sentence n="14">
+      n
+      </sentence>
+      <sentence n="15">
+      o
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+    stderr: |
+      vrt-scramble: Structure 'paragraph' between 'text' and 'sentence'
+    returncode: 1
+
+
+- name: 'vrt-scramble: Sentences within paragraphs'
+  input:
+    cmdline:
+    - vrt-scramble --within=paragraph --seed=1
+    - vrt-scramble --within=paragraph --unit=sentence --seed=1
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      <sentence n="1">
+      a
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="7">
+      g
+      </sentence>
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      </paragraph>
+      <paragraph n="3">
+      <sentence n="8">
+      h
+      </sentence>
+      <sentence n="9">
+      i
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="4">
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="10">
+      j
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      </paragraph>
+      <paragraph n="5">
+      <sentence n="15">
+      o
+      </sentence>
+      <sentence n="13">
+      m
+      </sentence>
+      <sentence n="14">
+      n
+      </sentence>
+      </paragraph>
+      </text>
+
+
+- name: 'vrt-scramble: Paragraphs within texts'
+  input:
+    cmdline:
+    - vrt-scramble --unit=paragraph --seed=1
+    - vrt-scramble --unit=paragraph --within=text --seed=1
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="2">
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="7">
+      g
+      </sentence>
+      </paragraph>
+      <paragraph n="3">
+      <sentence n="8">
+      h
+      </sentence>
+      <sentence n="9">
+      i
+      </sentence>
+      </paragraph>
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="4">
+      <sentence n="10">
+      j
+      </sentence>
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      </paragraph>
+      <paragraph n="5">
+      <sentence n="13">
+      m
+      </sentence>
+      <sentence n="14">
+      n
+      </sentence>
+      <sentence n="15">
+      o
+      </sentence>
+      </paragraph>
+      </text>
+
+
+- name: 'vrt-scramble: Sentences within texts'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1
+    - vrt-scramble --unit=sentence --within=text --seed=1
+    stdin: &input-ts
+      value: *input-1
+      transform:
+        shell: grep -v paragraph
+  output:
+    stdout: &output-ts-seed-1 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="9">
+      i
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      <sentence n="7">
+      g
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="8">
+      h
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="1">
+      a
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="15">
+      o
+      </sentence>
+      <sentence n="13">
+      m
+      </sentence>
+      <sentence n="14">
+      n
+      </sentence>
+      <sentence n="10">
+      j
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      </text>
+
+
+- name: 'vrt-scramble: Sentences within texts, infile as argument, --out'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1 --out=out.vrt in.vrt
+    file:in.vrt: *input-ts
+  output:
+    file:out.vrt: *output-ts-seed-1
+
+- name: 'vrt-scramble: Sentences within texts, infile as argument, --in-place'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1 --in-place in.vrt
+    file:in.vrt: *input-ts
+  output:
+    file:in.vrt: *output-ts-seed-1
+
+- name: 'vrt-scramble: Sentences within texts, infile as argument, --backup'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1 --backup=.bak in.vrt
+    file:in.vrt: *input-ts
+  output:
+    file:in.vrt: *output-ts-seed-1
+    # We cannot use "*input-ts" here, as it uses "transform", which
+    # does not work for output, which requires "transform-expected"
+    file:in.vrt.bak:
+      value: *input-1
+      transform-expected:
+        shell: grep -v paragraph
+
+- name: 'vrt-scramble: Sentences within texts, infile as argument, --in-sibling'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1 --in-sibling=scr in.vrt
+    file:in.vrt: *input-ts
+  output:
+    file:in.vrt.scr: *output-ts-seed-1
+
+- name: 'vrt-scramble: Sentences within texts, infile as argument, --in-sibling old/new'
+  input:
+    cmdline:
+    - vrt-scramble --seed=1 --in-sibling=vrt/vrts in.vrt
+    file:in.vrt: *input-ts
+  output:
+    file:in.vrts: *output-ts-seed-1
+
+
+- name: 'vrt-scramble: Sentences within texts, non-reproducible random seed'
+  input:
+    cmdline: |
+      vrt-scramble --seed="" in.vrt > out1.vrt;
+      vrt-scramble --seed="" in.vrt > out2.vrt
+    shell: True
+    file:in.vrt: *input-ts
+  output:
+    # The output of two consecutive runs with non-reproducible random
+    # seed should be different from each other
+    file:out1.vrt:
+      '!=':
+        file: out2.vrt

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -80,7 +80,7 @@
       <!-- #vrt positional-attributes: word -->
       <text n="1">
     stderr: |
-      vrt-scramble: <stdin>:3: Structure 'paragraph' between 'text' and 'sentence'
+      vrt-scramble: <stdin>:3: Structure 'paragraph' not allowed between container 'text' and shuffle item 'sentence'
     returncode: 1
   transform:
   - name: input from stdin
@@ -774,7 +774,7 @@
       <!-- #vrt positional-attributes: word -->
       <text n="1">
     stderr: |
-      vrt-scramble: <stdin>:12: Structure 'paragraph' between 'text' and 'sentence'
+      vrt-scramble: <stdin>:12: Structure 'paragraph' not allowed between container 'text' and shuffle item 'sentence'
     returncode: 1
 
 - name: 'vrt-scramble: Other structure end tag between container and shuffle item structures'
@@ -814,7 +814,7 @@
       </paragraph>
       <paragraph n="2">
     stderr: |
-      vrt-scramble: <stdin>:13: Structure 'bold' between 'paragraph' and 'sentence'
+      vrt-scramble: <stdin>:13: Structure 'bold' not allowed between container 'paragraph' and shuffle item 'sentence'
     returncode: 1
 
 
@@ -851,7 +851,7 @@
       <text n="1">
       <paragraph n="1">
     stderr: |
-      vrt-scramble: <stdin>:4: Structure 'sentence' between 'paragraph' and 'clause'
+      vrt-scramble: <stdin>:4: Structure 'sentence' not allowed between container 'paragraph' and shuffle item 'clause'
     returncode: 1
 
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -554,3 +554,111 @@
     input:
       cmdline:
         replace: '/--seed/--legacy --seed/'
+
+
+- name: 'vrt-scramble: Read seed from file'
+  input:
+    cmdline: vrt-scramble --seed="<seed.txt"
+    stdin: *input-ts
+    file:seed.txt: '1'
+  output:
+    stdout: *output-ts-seed-1
+  transform:
+  - {}
+  - name: seed from file same as literal seed
+    input:
+      cmdline:
+        replace: '/<seed\.txt/1/'
+  - name: spaces around file name stripped
+    input:
+      cmdline:
+        replace: '/<seed.txt/< \tseed.txt \t/'
+
+- name: 'vrt-scramble: Read seed from 1 MiB file'
+  input:
+    cmdline: vrt-scramble --seed="<seed.txt"
+    stdin: *input-ts
+    file:seed.txt:
+      value:
+        python: return pow(2, 20) * '0'
+  output:
+    stdout: &output-ts-1mib |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <sentence n="9">
+      i
+      </sentence>
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="6">
+      f
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      <sentence n="8">
+      h
+      </sentence>
+      <sentence n="5">
+      e
+      </sentence>
+      <sentence n="7">
+      g
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </text>
+      <text n="2">
+      <sentence n="14">
+      n
+      </sentence>
+      <sentence n="11">
+      k
+      </sentence>
+      <sentence n="15">
+      o
+      </sentence>
+      <sentence n="13">
+      m
+      </sentence>
+      <sentence n="12">
+      l
+      </sentence>
+      <sentence n="10">
+      j
+      </sentence>
+      </text>
+  transform:
+  - {}
+  # The seed file with something appended should produce the same
+  # result, as only the first 1 MiB of the seed file is used
+  - name: append to 1 MiB seed
+    input:
+      file:seed.txt:
+        append: 'a'
+
+- name: 'vrt-scramble: Read seed from 1 MiB - 1 byte file'
+  input:
+    cmdline: vrt-scramble --seed="<seed.txt"
+    stdin: *input-ts
+    file:seed.txt:
+      value:
+        python: return (pow(2, 20) - 1) * '0'
+  output:
+    stdout:
+      '!=': *output-ts-1mib
+
+- name: 'vrt-scramble: Non-existent seed file'
+  input:
+    cmdline: vrt-scramble --seed="<seed.txt"
+    stdin: *input-ts
+  output:
+    stdout: ''
+    stderr: |
+      vrt-scramble: Cannot read random seed from file seed.txt: [Errno 2] No such file or directory: 'seed.txt'
+    returncode: 1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -664,7 +664,7 @@
     returncode: 1
 
 
-- name: 'vrt-scramble: Comments within structures to be scrambled'
+- name: 'vrt-scramble: Comments within structures to be shuffled'
   input:
     cmdline: vrt-scramble --within=text --unit=sentence --seed=1
     stdin: |
@@ -742,7 +742,7 @@
       <!-- Comment after text end tag 2 -->
 
 
-- name: 'vrt-scramble: Other structure between within and unit, not starting at the beginning of within'
+- name: 'vrt-scramble: Other structure between container and shuffle item structures, not starting at the beginning of container'
   input:
     cmdline: vrt-scramble --within=text --unit=sentence --seed=1
     stdin: |
@@ -777,7 +777,7 @@
       vrt-scramble: <stdin>:12: Structure 'paragraph' between 'text' and 'sentence'
     returncode: 1
 
-- name: 'vrt-scramble: Other structure end tag between within and unit'
+- name: 'vrt-scramble: Other structure end tag between container and shuffle item structures'
   input:
     cmdline: vrt-scramble --within=paragraph --unit=sentence --seed=1
     stdin: |
@@ -818,18 +818,18 @@
     returncode: 1
 
 
-- name: 'vrt-scramble: Unit the same as within'
+- name: 'vrt-scramble: Container the same as shuffle item'
   input:
     cmdline: vrt-scramble --within=sentence --unit=sentence --seed=1
     stdin: *input-ts
   output:
     stdout: ''
     stderr: |
-      vrt-scramble: The structure to scramble and the containing structure may not be the same
+      vrt-scramble: The structure to shuffle and the containing structure may not be the same
     returncode: 1
 
 
-- name: 'vrt-scramble: No within in the input'
+- name: 'vrt-scramble: No container in the input'
   input:
     cmdline:
     # No within
@@ -841,7 +841,7 @@
     # Output input intact
     stdout: *input-1
 
-- name: 'vrt-scramble: No unit in the input'
+- name: 'vrt-scramble: No shuffle unit in the input'
   input:
     cmdline: vrt-scramble --within=paragraph --unit=clause --seed=1
     stdin: *input-1
@@ -855,7 +855,7 @@
     returncode: 1
 
 
-- name: 'vrt-scramble: Structures outside within'
+- name: 'vrt-scramble: Structures outside container'
   input:
     cmdline: vrt-scramble --within=text --unit=sentence --seed=1
     stdin: |

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -80,8 +80,19 @@
       <!-- #vrt positional-attributes: word -->
       <text n="1">
     stderr: |
-      vrt-scramble: Structure 'paragraph' between 'text' and 'sentence'
+      vrt-scramble: <stdin>:3: Structure 'paragraph' between 'text' and 'sentence'
     returncode: 1
+  transform:
+  - name: input from stdin
+    # No transformations: use input and output as above
+  - name: input file as argument
+    input:
+      cmdline: vrt-scramble in.vrt
+      file:in.vrt: *input-1
+      stdin: ''
+    output-expected:
+      stderr:
+        replace: '/<stdin>/in.vrt/'
 
 
 - name: 'vrt-scramble: Sentences within paragraphs'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_scramble.yaml
@@ -827,3 +827,87 @@
     stderr: |
       vrt-scramble: The structure to scramble and the containing structure may not be the same
     returncode: 1
+
+
+- name: 'vrt-scramble: No within in the input'
+  input:
+    cmdline:
+    # No within
+    - vrt-scramble --within=corpus --unit=sentence --seed=1
+    # No within nor unit
+    - vrt-scramble --within=corpus --unit=clause --seed=1
+    stdin: *input-1
+  output:
+    # Output input intact
+    stdout: *input-1
+
+- name: 'vrt-scramble: No unit in the input'
+  input:
+    cmdline: vrt-scramble --within=paragraph --unit=clause --seed=1
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+    stderr: |
+      vrt-scramble: <stdin>:4: Structure 'sentence' between 'paragraph' and 'clause'
+    returncode: 1
+
+
+- name: 'vrt-scramble: Structures outside within'
+  input:
+    cmdline: vrt-scramble --within=text --unit=sentence --seed=1
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <!-- Comment before collection -->
+      <collection n="1">
+      <!-- Comment between collection and corpus -->
+      <corpus n="1">
+      <!-- Comment between corpus and text -->
+      <text n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </text>
+      <!-- Comment between text and corpus -->
+      </corpus>
+      <!-- Comment between corpus and collection -->
+      </collection>
+      <!-- Comment after collection -->
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <!-- Comment before collection -->
+      <collection n="1">
+      <!-- Comment between collection and corpus -->
+      <corpus n="1">
+      <!-- Comment between corpus and text -->
+      <text n="1">
+      <sentence n="3">
+      c
+      </sentence>
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      <sentence n="4">
+      d
+      </sentence>
+      </text>
+      <!-- Comment between text and corpus -->
+      </corpus>
+      <!-- Comment between corpus and collection -->
+      </collection>
+      <!-- Comment after collection -->

--- a/vrt-tools/vrt-scramble
+++ b/vrt-tools/vrt-scramble
@@ -1,0 +1,17 @@
+#! /usr/bin/env python3
+# -*- mode: Python; -*-
+
+"""
+vrt-scramble
+
+A VRT tool to scramble (randomly shuffle) structures in a VRT input.
+
+The actual implementation is in libvrt.tools.vrt_scramble.
+"""
+
+
+from libvrt.tools.vrt_scramble import VrtScrambler
+
+
+if __name__ == '__main__':
+    VrtScrambler().run()

--- a/vrt-tools/vrtargsoolib.py
+++ b/vrt-tools/vrtargsoolib.py
@@ -272,20 +272,26 @@ def _argparser_add_arg(argparser, argspec):
     argparser.add_argument(*argnames, **argdict)
 
 
-def error_exit(*msg, progname=None, exitcode=1):
+def error_exit(*msg, exitcode=1, **kwargs):
     """Print message msg to standard error and exit with code exitcode.
 
-    If progname is not None, prepend it to the error message.
+    kwargs may contain progname, filename and/or linenr: if not None,
+    prepend them to the error message.
     """
-    print_error(*msg, progname=progname)
+    print_error(*msg, **kwargs)
     exit(exitcode)
 
 
-def print_error(*msg, progname=None):
+def print_error(*msg, progname=None, filename=None, linenr=None):
     """Print message msg to standard error.
 
-    If progname is not None, prepend it to the error message.
+    If progname, filename and/or linenr is not None, prepend them to
+    the error message.
     """
+    if filename is not None:
+        if linenr is not None:
+            filename += ':' + str(linenr)
+        msg = (filename + ':',) + msg
     if progname is not None:
         msg = (progname + ':',) + msg
     print(*msg, file=sys.stderr)
@@ -395,17 +401,26 @@ class BasicProcessor:
         """Check command-line arguments and assign them to self._args."""
         self._args = args
 
-    def print_error(self, *msg):
-        """Print message msg to standard error."""
-        print_error(*msg, progname=self._progname)
+    def print_error(self, *msg, **kwargs):
+        """Print message msg to standard error.
 
-    def warn(self, *msg):
-        """Print message msg prepended with "Warning:" to standard error."""
-        self.print_error('Warning:', *msg)
+        Prepend program name and possible filename and linenr from kwargs.
+        """
+        print_error(*msg, progname=self._progname, **kwargs)
 
-    def error_exit(self, *msg, exitcode=1):
-        """Print message msg to standard error and exit with code exitcode."""
-        error_exit(*msg, progname=self._progname, exitcode=exitcode)
+    def warn(self, *msg, **kwargs):
+        """Print message msg prepended with "Warning:" to standard error.
+
+        Prepend program name and possible filename and linenr from kwargs.
+        """
+        self.print_error('Warning:', *msg, **kwargs)
+
+    def error_exit(self, *msg, exitcode=1, **kwargs):
+        """Print message msg to standard error and exit with code exitcode.
+
+        Prepend program name and possible filename and linenr from kwargs.
+        """
+        error_exit(*msg, exitcode=exitcode, progname=self._progname, **kwargs)
 
 
 class InputProcessor(BasicProcessor):

--- a/vrt-tools/vrtargsoolib.py
+++ b/vrt-tools/vrtargsoolib.py
@@ -272,13 +272,13 @@ def _argparser_add_arg(argparser, argspec):
     argparser.add_argument(*argnames, **argdict)
 
 
-def error_exit(*msg, progname=None):
-    """Print message msg to standard error and exit with code 1.
+def error_exit(*msg, progname=None, exitcode=1):
+    """Print message msg to standard error and exit with code exitcode.
 
     If progname is not None, prepend it to the error message.
     """
     print_error(*msg, progname=progname)
-    exit(1)
+    exit(exitcode)
 
 
 def print_error(*msg, progname=None):
@@ -403,9 +403,9 @@ class BasicProcessor:
         """Print message msg prepended with "Warning:" to standard error."""
         self.print_error('Warning:', *msg)
 
-    def error_exit(self, *msg):
-        """Print message msg to standard error and exit with code 1."""
-        error_exit(*msg, progname=self._progname)
+    def error_exit(self, *msg, exitcode=1):
+        """Print message msg to standard error and exit with code exitcode."""
+        error_exit(*msg, progname=self._progname, exitcode=exitcode)
 
 
 class InputProcessor(BasicProcessor):


### PR DESCRIPTION
The new VRT Tool [`vrt-scramble`](../blob/https://github.com/CSCfi/Kielipankki-utilities/blob/48a299b4/vrt-tools/vrt-scramble) scrambles the the input VRT by randomly shuffling specified structures (elements), such as sentences, within containing structures, such as texts. It is a based on the older script [`vrt-scramble.py`](https://github.com/CSCfi/Kielipankki-utilities/blob/master/scripts/vrt-scramble.py) but has the standard VRT Tools file options and is about twice as fast because of reading and writing in binary and replacing regular expression matching with string operations.

The usage message of the script is the following (the descriptions of common VRT Tool options omitted):

```
usage: vrt-scramble [-h] [--out file | --in-place | --backup bak | --in-sibling EXT]
                    [--version] [--unit struct] [--within struct] [--seed string] [--legacy]
                    [file]

Scramble the input VRT by randomly shuffling specified structures (elements), such as
sentences, within containing structures, such as texts, and output the scrambled VRT. Note that
the input may not have intermediate structures between the containing structures and the
structures to be shuffled; for example, if sentences are shuffled within texts, the input may
not have paragraphs between them.

positional arguments:
  file                  input file (default stdin)

options:
  [... Common VRT Tool options ...]
  --unit struct         shuffle struct structures (elements) (default: "sentence")
  --within struct       shuffle structures within struct structures (elements): structures are
                        not moved across struct boundaries (default: "text")
  --seed string         use string as the random number generator seed; if string begins with
                        "<", the rest is the name of the file whose content (up to 1 MiB) to
                        use as the seed (default: "" = non-reproducible output)
  --legacy              produce the same result as the old vrt-scramble.py for any non-empty
                        seed
```

The usage message uses _structure_ to refer to what in CWB is called _structural attributes_ and what resembles XML _elements_ except that they need not be strictly nested.

On a Puhti `sinteractive` session, the script scrambled a VRT input with about 28,000 texts, 4.6 million sentences and 41.7 million tokens with parse attributes in about 26 seconds.

My intention is to use the tool in [`korp-make`](../blob/master/scripts/korp-make) with a seed generated by [`vrt-extract-seed`](../blob/41d2b627/vrt-tools/vrt-extract-seed), replacing the old `vrt-scramble.py`.