### PR TITLE
Add `vrt-drop-empty`: Remove empty structures (elements)

### DIFF
--- a/vrt-tools/libvrt/tools/vrt_drop_empty.py
+++ b/vrt-tools/libvrt/tools/vrt_drop_empty.py
@@ -9,7 +9,9 @@ Please run "vrt-drop-empty -h" for more information.
 
 
 import re
+import sys
 
+from collections import defaultdict
 from itertools import groupby
 
 from vrtargsoolib import InputProcessor
@@ -25,12 +27,17 @@ class VrtEmptyStructDropper(InputProcessor):
     represented in CWB data and are ignored by cwb-encode. XML-style
     comment lines within empty structures are retained.
     """
+    ARGSPECS = [
+        ('--verbose|-v',
+         '''output the number of dropped structures to stderr''')
+    ]
 
     def __init__(self):
         super().__init__()
 
     def main(self, args, inf, ouf):
         """Read inf, write to ouf, with command-line arguments args."""
+        drop_counts = defaultdict(int)
 
         def drop_empty(lines):
             """Return generator iterating over lines not forming empty struct."""
@@ -44,6 +51,7 @@ class VrtEmptyStructDropper(InputProcessor):
                         drop_line_nums.add(linenum)
                         drop_line_nums.add(struct_stack[-1][1])
                         struct_stack.pop()
+                        drop_counts[struct] += 1
                 elif not line.startswith(b'<!'):
                     # Start tag
                     struct = line[1:].partition(b' ')[0].rstrip(b'>\n')
@@ -51,9 +59,21 @@ class VrtEmptyStructDropper(InputProcessor):
             return (line for linenum, line in enumerate(lines)
                     if linenum not in drop_line_nums)
 
+        def output_drop_counts():
+            """Output the number of structures dropped."""
+            if not drop_counts:
+                sys.stderr.write('No structures dropped\n')
+            else:
+                sys.stderr.write('Dropped structures:\n')
+                for struct in sorted(drop_counts.keys()):
+                    sys.stderr.write(
+                        f'  {struct.decode("UTF-8")}: {drop_counts[struct]}\n')
+
         LT = b'<'[0]
         for istag, lines in groupby(inf, lambda line: line[0] == LT):
             if istag:
                 lines = drop_empty(list(lines))
             for line in lines:
                 ouf.write(line)
+        if args.verbose:
+            output_drop_counts()

--- a/vrt-tools/libvrt/tools/vrt_drop_empty.py
+++ b/vrt-tools/libvrt/tools/vrt_drop_empty.py
@@ -1,0 +1,59 @@
+
+"""
+vrt_drop_empty.py
+
+The actual implementation of vrt-drop-empty.
+
+Please run "vrt-drop-empty -h" for more information.
+"""
+
+
+import re
+
+from itertools import groupby
+
+from vrtargsoolib import InputProcessor
+
+
+class VrtEmptyStructDropper(InputProcessor):
+
+    """Class implementing vrt-drop-empty functionality."""
+
+    DESCRIPTION = """
+    Drop (remove) empty structures (elements) from the input VRT, that
+    is, structures containing no tokens. Such structures cannot be
+    represented in CWB data and are ignored by cwb-encode. XML-style
+    comment lines within empty structures are retained.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self, args, inf, ouf):
+        """Read inf, write to ouf, with command-line arguments args."""
+
+        def drop_empty(lines):
+            """Return generator iterating over lines not forming empty struct."""
+            struct_stack = []
+            drop_line_nums = set()
+            for linenum, line in enumerate(lines):
+                if line.startswith(b'</'):
+                    # End tag
+                    struct = line[2:-2]
+                    if struct_stack and struct_stack[-1][0] == struct:
+                        drop_line_nums.add(linenum)
+                        drop_line_nums.add(struct_stack[-1][1])
+                        struct_stack.pop()
+                elif not line.startswith(b'<!'):
+                    # Start tag
+                    struct = line[1:].partition(b' ')[0].rstrip(b'>\n')
+                    struct_stack.append((struct, linenum))
+            return (line for linenum, line in enumerate(lines)
+                    if linenum not in drop_line_nums)
+
+        LT = b'<'[0]
+        for istag, lines in groupby(inf, lambda line: line[0] == LT):
+            if istag:
+                lines = drop_empty(list(lines))
+            for line in lines:
+                ouf.write(line)

--- a/vrt-tools/tests/scripttests/scripttest_vrt_drop_empty.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_drop_empty.yaml
@@ -44,6 +44,14 @@
       </text>
   output:
     stdout: *input-1
+  transform:
+  - {}
+  - input: &verbose
+      cmdline:
+        append: ' --verbose'
+    output:
+      stderr: |
+        No structures dropped
 
 
 - name: 'vrt-drop-empty: Empty sentence at the beginning'
@@ -77,6 +85,13 @@
       transform:
         python: |
           return value.replace('<sentence n="1">\n</sentence>\n', '')
+  transform: &transform-verbose-1s
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          sentence: 1
 
 - name: 'vrt-drop-empty: Empty sentence in the middle'
   input:
@@ -109,6 +124,7 @@
       transform:
         python: |
           return value.replace('<sentence n="2">\n</sentence>\n', '')
+  transform: *transform-verbose-1s
 
 - name: 'vrt-drop-empty: Empty sentence at the end'
   input:
@@ -144,6 +160,7 @@
       transform:
         python: |
           return value.replace('<sentence n="6">\n</sentence>\n', '')
+  transform: *transform-verbose-1s
 
 - name: 'vrt-drop-empty: Multiple empty sentences'
   input:
@@ -178,6 +195,13 @@
       transform:
         python: |
           return re.sub('<sentence n="[16]">\n</sentence>\n', '', value)
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          sentence: 2
 
 - name: 'vrt-drop-empty: Multiple consecutive empty sentences'
   input:
@@ -217,6 +241,13 @@
       transform:
         python: |
           return re.sub('<sentence n="1[abc]">\n</sentence>\n', '', value)
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          sentence: 3
 
 - name: 'vrt-drop-empty: Empty paragraphs and texts'
   input:
@@ -250,6 +281,14 @@
         python: |
           value = re.sub('<paragraph n="1">\n</paragraph>\n', '', value)
           return re.sub('<text n="3">\n</text>\n', '', value)
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          paragraph: 1
+          text: 1
 
 
 - name: 'vrt-drop-empty: Empty paragraphs and texts containing lower-level structures'
@@ -285,6 +324,15 @@
       </sentence>
       </paragraph>
       </text>
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          paragraph: 3
+          sentence: 2
+          text: 1
 
 - name: 'vrt-drop-empty: Empty structures without attributes'
   input:
@@ -318,6 +366,15 @@
           value = re.sub('<sentence>\n</sentence>\n', '', value)
           value = re.sub('<paragraph>\n</paragraph>\n', '', value)
           return re.sub('<text>\n</text>\n', '', value)
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          paragraph: 2
+          sentence: 1
+          text: 2
 
 
 - name: 'vrt-drop-empty: Empty structure within a sentence'
@@ -345,6 +402,13 @@
       </sentence>
       </paragraph>
       </text>
+  transform:
+  - {}
+  - input: *verbose
+    output:
+      stderr: |
+        Dropped structures:
+          ne: 1
 
 
 - name: 'vrt-drop-empty: Comment within an empty structure'
@@ -376,3 +440,4 @@
       <!-- Comment after -->
       </paragraph>
       </text>
+  transform: *transform-verbose-1s

--- a/vrt-tools/tests/scripttests/scripttest_vrt_drop_empty.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_drop_empty.yaml
@@ -1,0 +1,378 @@
+
+# scripttestlib tests for vrt-drop-empty
+
+
+# Default input and output
+
+- defaults:
+    input:
+      cmdline: vrt-drop-empty
+    output:
+      # No errors
+      returncode: 0
+      stderr: ''
+
+
+- name: 'vrt-drop-empty: No empty structures'
+  input:
+    stdin: &input-1 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      <sentence n="4">
+      f
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: *input-1
+
+
+- name: 'vrt-drop-empty: Empty sentence at the beginning'
+  input:
+    stdin: &input-2 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout:
+      value: *input-2
+      transform:
+        python: |
+          return value.replace('<sentence n="1">\n</sentence>\n', '')
+
+- name: 'vrt-drop-empty: Empty sentence in the middle'
+  input:
+    stdin: &input-3 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout:
+      value: *input-3
+      transform:
+        python: |
+          return value.replace('<sentence n="2">\n</sentence>\n', '')
+
+- name: 'vrt-drop-empty: Empty sentence at the end'
+  input:
+    stdin: &input-4 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      <sentence n="6">
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout:
+      value: *input-4
+      transform:
+        python: |
+          return value.replace('<sentence n="6">\n</sentence>\n', '')
+
+- name: 'vrt-drop-empty: Multiple empty sentences'
+  input:
+    stdin: &input-5 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      <sentence n="6">
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout:
+      value: *input-5
+      transform:
+        python: |
+          return re.sub('<sentence n="[16]">\n</sentence>\n', '', value)
+
+- name: 'vrt-drop-empty: Multiple consecutive empty sentences'
+  input:
+    stdin: &input-6 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1a">
+      </sentence>
+      <sentence n="1b">
+      </sentence>
+      <sentence n="1c">
+      </sentence>
+      <sentence n="2">
+      b
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      <sentence n="6">
+      k
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout:
+      value: *input-6
+      transform:
+        python: |
+          return re.sub('<sentence n="1[abc]">\n</sentence>\n', '', value)
+
+- name: 'vrt-drop-empty: Empty paragraphs and texts'
+  input:
+    stdin: &input-7 |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      </paragraph>
+      <paragraph n="2">
+      <sentence n="3">
+      e
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      j
+      </sentence>
+      <sentence n="6">
+      k
+      </sentence>
+      </paragraph>
+      </text>
+      <text n="3">
+      </text>
+  output:
+    stdout:
+      value: *input-7
+      transform:
+        python: |
+          value = re.sub('<paragraph n="1">\n</paragraph>\n', '', value)
+          return re.sub('<text n="3">\n</text>\n', '', value)
+
+
+- name: 'vrt-drop-empty: Empty paragraphs and texts containing lower-level structures'
+  input:
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      </sentence>
+      </paragraph>
+      <paragraph n="2">
+      </paragraph>
+      </text>
+      <text n="2">
+      <paragraph n="3">
+      <sentence n="5">
+      </sentence>
+      </paragraph>
+      <paragraph n="4">
+      <sentence n="6">
+      k
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="2">
+      <paragraph n="4">
+      <sentence n="6">
+      k
+      </sentence>
+      </paragraph>
+      </text>
+
+- name: 'vrt-drop-empty: Empty structures without attributes'
+  input:
+    stdin: &input-8 |
+      <!-- #vrt positional-attributes: word -->
+      <text>
+      <paragraph>
+      </paragraph>
+      <paragraph>
+      <sentence>
+      </sentence>
+      </paragraph>
+      </text>
+      <text>
+      <paragraph>
+      <sentence>
+      j
+      </sentence>
+      <sentence>
+      k
+      </sentence>
+      </paragraph>
+      </text>
+      <text>
+      </text>
+  output:
+    stdout:
+      value: *input-8
+      transform:
+        python: |
+          value = re.sub('<sentence>\n</sentence>\n', '', value)
+          value = re.sub('<paragraph>\n</paragraph>\n', '', value)
+          return re.sub('<text>\n</text>\n', '', value)
+
+
+- name: 'vrt-drop-empty: Empty structure within a sentence'
+  input:
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      <ne n="1">
+      </ne>
+      b
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      b
+      </sentence>
+      </paragraph>
+      </text>
+
+
+- name: 'vrt-drop-empty: Comment within an empty structure'
+  input:
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <!-- Comment before -->
+      <sentence n="2">
+      <!-- Comment in -->
+      </sentence>
+      <!-- Comment after -->
+      </paragraph>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text n="1">
+      <paragraph n="1">
+      <sentence n="1">
+      a
+      </sentence>
+      <!-- Comment before -->
+      <!-- Comment in -->
+      <!-- Comment after -->
+      </paragraph>
+      </text>

--- a/vrt-tools/vrt-drop-empty
+++ b/vrt-tools/vrt-drop-empty
@@ -1,0 +1,17 @@
+#! /usr/bin/env python3
+# -*- mode: Python; -*-
+
+"""
+vrt-drop-empty
+
+A VRT tool to drop (remove) empty structures (elements) in a VRT input.
+
+The actual implementation is in libvrt.tools.vrt_drop_empty.
+"""
+
+
+from libvrt.tools.vrt_drop_empty import VrtEmptyStructDropper
+
+
+if __name__ == '__main__':
+    VrtEmptyStructDropper().run()


### PR DESCRIPTION
Add `vrt-drop-empty`, a simple VRT tool to remove structures (elements) containing no tokens. The tool removes the largest structures containing no tokens; for example, if a paragraph contains only sentences without tokens, the paragraph is also removed.

Usage:

```
usage: vrt-drop-empty [-h] [--out file | --in-place | --backup bak | --in-sibling EXT] [--version]
                      [--verbose]
                      [file]

Drop (remove) empty structures (elements) from the input VRT, that is, structures containing no
tokens. Such structures cannot be represented in CWB data and are ignored by cwb-encode. XML-style
comment lines within empty structures are retained.

positional arguments:
  file                  input file (default stdin)

options:
  [… Standard VRT tool options …]
  --verbose, -v         output the number of dropped structures to stderr
```