### PR TITLE
Add `vrt-drop-attrs`: Remove structural attributes (annotations) by name

### DIFF
--- a/vrt-tools/libvrt/metaline.py
+++ b/vrt-tools/libvrt/metaline.py
@@ -160,11 +160,9 @@ def starttag(struct, attrs, sort=False):
 
 def _get_attrs(attrs, sort=False):
     '''Return items from attrs (dict or list of pairs), sorted if sort.'''
-    try:
-        items = attrs.items()
-    except AttributeError:
-        items = attrs
-    return sorted(items) if sort else items
+    if isinstance(attrs, dict):
+        attrs = attrs.items()
+    return sorted(attrs) if sort else attrs
 
 def strstarttag(struct, attrs, sort=False):
     '''Start tag line for struct (str) with attrs (str, str).

--- a/vrt-tools/libvrt/tools/vrt_drop_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_drop_attrs.py
@@ -1,0 +1,123 @@
+
+"""
+vrt_drop_attrs.py
+
+The actual implementation of vrt-drop-attrs.
+
+Please run "vrt-drop-attrs -h" for more information.
+"""
+
+
+import sys
+import re
+
+from collections import defaultdict, OrderedDict
+
+from libvrt import metaline as ml
+from libvrt.argtypes import encode_utf8, attr_regex_list_combined
+
+from vrtargsoolib import InputProcessor
+
+
+class VrtStructAttrDropper(InputProcessor):
+
+    """Class implementing vrt-drop-attrs functionality."""
+
+    DESCRIPTION = """
+    Drop (remove) the structural attributes (annotations) in the input
+    VRT whose name matches a specified regular expression.
+    """
+    ARGSPECS = [
+        ('#GROUPED structure-specific options',
+         '''The following options can be specified multiple times: each
+            occurrence applies to the --structure after which it is
+            specified. If an option is specified before any --structure, it
+            becomes the default for all structures.''',
+         [
+             ('--structure|element|e = struct:encode_utf8',
+              '''the options following this (up to the next --structure)
+                 apply to structures struct'''),
+             ('--drop = attr-regex-list:attr_regex_list_combined',
+              '''drop attributes whose names fully match a regular
+                 expression in attr-regex-list (separated by commas or
+                 spaces) and are not matched by a regular expression
+                 specified with --keep''',
+              dict(silent_default=attr_regex_list_combined(''))),
+             ('--keep = attr-regex-list:attr_regex_list_combined',
+              '''keep attributes whose names fully match a regular
+                 expression in attr-regex-list even if they were
+                 matched by a regular expression specified with --drop''',
+              dict(silent_default=attr_regex_list_combined(''))),
+         ]),
+    ]
+
+    def __init__(self):
+        # extra_types=... is needed for using module-level functions
+        # as types in ARGSPECS (otherwise, type could be passed via a
+        # dict)
+        super().__init__(extra_types=globals())
+
+    def check_args(self, args):
+        """Check and modify `args` (parsed command line arguments)."""
+        super().check_args(args)
+
+    def main(self, args, inf, ouf):
+        """Read `inf`, write to `ouf`, with command-line arguments `args`."""
+
+        # Attribute names by structure name, already tested to be
+        # dropped or kept: value 1 = drop, 2 = keep. These values
+        # instead of False and True make it simpler and faster(?) to
+        # handle the case in which an attribute name is not found in
+        # the dict (in drop_attrs), as we can use an "or" expression
+        # for that, evaluated only if the attribute is not in
+        # keep_attr, regardless of its value.
+        keep_attr = defaultdict(dict)
+        # The values of command-line options --drop and --keep by
+        # structure name; if not explicitly specified, the default
+        struct_args = defaultdict(dict)
+
+        def getarg(name, struct):
+            """Return the value for argument `name` for structure `struct`.
+
+            If --structure=struct has not been specified, use the
+            default value for `name` in `args`.
+            Cache the values in `struct_args`.
+            """
+            if struct not in struct_args[name]:
+                struct_args[name][struct] = (
+                    getattr(args.structure.get(struct), name, None)
+                    or getattr(args, name))
+            return struct_args[name][struct]
+
+        def check_keep_attr(struct, attrname):
+            """Check if `attrname` in `struct` should be kept or dropped.
+
+            Return 1 if `attrname` should be dropped, 2 if kept. Also
+            store the result to `keep_attr[struct][attrname]` for
+            faster future reference.
+            """
+            drop = getarg('drop', struct)
+            keep = getarg('keep', struct)
+            # Possible None returned by fullmatch needs to be
+            # converted to bool first, as int(None) raises TypeError;
+            # "not not x" is somewhat faster than "bool(x)"
+            result = int((drop and not drop.fullmatch(attrname))
+                         or (keep and not not keep.fullmatch(attrname))) + 1
+            keep_attr[struct][attrname] = result
+            return result
+
+        def drop_attrs(line):
+            """Return start tag line `line` with attributes dropped.
+
+            Drop attributes as specified with command-line options.
+            """
+            struct = ml.element(line)
+            return ml.starttag(
+                struct, ((name, val) for name, val in ml.pairs(line)
+                         if (keep_attr[struct].get(name)
+                             or check_keep_attr(struct, name)) - 1))
+
+        for line in inf:
+            if ml.ismeta(line) and ml.isstarttag(line):
+                line = drop_attrs(line)
+            ouf.write(line)

--- a/vrt-tools/tests/libvrt/test_metaline.py
+++ b/vrt-tools/tests/libvrt/test_metaline.py
@@ -60,18 +60,40 @@ class TestElement:
         assert ml.strelement(input) == expected
 
 
+def _add_sort(paramlist):
+    """Add parameter sort to items in paramlist, to parametrize TestStarttag.
+
+    This function is used to expand the parameter list to TestStarttag
+    methods to reduce redundancy in the list.
+
+    paramlist is a list of pairs (attrs, expected), where the value of
+    expected can be str or dict[bool, str]. If str, the value is
+    expected to result with both False and True values for the sort
+    argument. If dict, the key is the value of the sort argument and
+    the value the expected result.
+
+    The function returns triple (attrs, sort, expected), to be passed
+    to TestStarttag methods, with sort extracted from the expected of
+    paramlist.
+    """
+    result = []
+    for attrs, expected in paramlist:
+        if not isinstance(expected, dict):
+            expected = {False: expected, True: expected}
+        for sort, expected1 in expected.items():
+            result.append((attrs, sort, expected1))
+    return result
+
+
 @pytest.mark.parametrize(
     'attrs,sort,expected',
-    [
-        ([], False, '<elem>\n'),
-        ([], True, '<elem>\n'),
-        ([('a', 'b')], False, '<elem a="b">\n'),
-        ([('a', 'b')], True, '<elem a="b">\n'),
-        ([('a', 'b'), ('b', 'c')], False, '<elem a="b" b="c">\n'),
-        ([('a', 'b'), ('b', 'c')], True, '<elem a="b" b="c">\n'),
-        ([('b', 'b'), ('a', 'c')], False, '<elem b="b" a="c">\n'),
-        ([('b', 'b'), ('a', 'c')], True, '<elem a="c" b="b">\n'),
-    ])
+    _add_sort([
+        ([], '<elem>\n'),
+        ([('a', 'b')], '<elem a="b">\n'),
+        ([('a', 'b'), ('b', 'c')], '<elem a="b" b="c">\n'),
+        ([('b', 'b'), ('a', 'c')], {False: '<elem b="b" a="c">\n',
+                                    True: '<elem a="c" b="b">\n'}),
+    ]))
 class TestStartTag:
 
     """Tests for functions starttag, strstarttag."""

--- a/vrt-tools/tests/libvrt/test_metaline.py
+++ b/vrt-tools/tests/libvrt/test_metaline.py
@@ -106,6 +106,10 @@ def _add_sort(paramlist):
         ([], '<elem>\n'),
         ([('a', 'b')], '<elem a="b">\n'),
         ([('a', 'b'), ('b', 'c')], '<elem a="b" b="c">\n'),
+        # Attribute values are not (re-)encoded
+        ([('a', '&amp;&quot;<')], '<elem a="&amp;&quot;<">\n'),
+        # Attribute name beginning with an underscore
+        ([('_ab1', 'cd')], '<elem _ab1="cd">\n'),
         ([('b', 'b'), ('a', 'c')], {False: '<elem b="b" a="c">\n',
                                     True: '<elem a="c" b="b">\n'}),
     ]))

--- a/vrt-tools/tests/scripttests/scripttest_vrt_drop_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_drop_attrs.yaml
@@ -410,3 +410,75 @@
       </sentence>
       </text>
   transform: *transform-comma-space
+
+
+# --verbose
+
+- name: 'vrt-drop-attrs: --verbose, nothing dropped'
+  input:
+    cmdline:
+    - vrt-drop-attrs --verbose
+    - vrt-drop-attrs --verbose --drop="d,.*_"
+    - vrt-drop-attrs --verbose --structure=paragraph --drop="a,b"
+    stdin: *input-2
+  output:
+    stdout: *input-2
+    stderr: |
+      No attributes dropped
+
+- name: 'vrt-drop-attrs: --verbose, attributes dropped'
+  input:
+    cmdline: vrt-drop-attrs --verbose --drop="[abyz]"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text c="d" de="e" _fg="f">
+      <sentence cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text c="x" de="w" _fg="v">
+      <sentence cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6">
+      c
+      </sentence>
+      </text>
+    stderr: |
+      Number of attributes dropped:
+      structure	attribute	count
+      text	a	2
+      text	b	2
+      text	y	1
+      sentence	a	3
+      sentence	b	3
+      sentence	z	1
+
+- name: 'vrt-drop-attrs: --verbose, attributes dropped, structure-specific'
+  input:
+    cmdline: vrt-drop-attrs --verbose --structure=text --drop="[abyz]"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text c="d" de="e" _fg="f">
+      <sentence z="_" a="0" b="1" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text c="x" de="w" _fg="v">
+      <sentence a="1" b="2" cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6" a="3" b="4">
+      c
+      </sentence>
+      </text>
+    stderr: |
+      Number of attributes dropped:
+      structure	attribute	count
+      text	a	2
+      text	b	2
+      text	y	1

--- a/vrt-tools/tests/scripttests/scripttest_vrt_drop_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_drop_attrs.yaml
@@ -1,0 +1,412 @@
+
+# scripttestlib tests for vrt-drop-attrs
+
+
+# Default input and output
+
+- defaults:
+    output:
+      # No errors
+      returncode: 0
+      stderr: ''
+
+
+- name: 'vrt-drop-attrs: No changes: no attributes'
+  input:
+    cmdline: vrt-drop-attrs
+    stdin: &input-noattrs |
+      <!-- #vrt positional-attributes: word -->
+      <text>
+      <paragraph>
+      <sentence>
+      a
+      </sentence>
+      </paragraph>
+      </text>
+  output:
+    stdout: *input-noattrs
+
+- name: 'vrt-drop-attrs: No changes: no options specified'
+  input:
+    cmdline: vrt-drop-attrs
+    stdin: &input-1 |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d">
+      <sentence z="_" a="0" b="1">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x">
+      <sentence a="1" b="2">
+      b
+      </sentence>
+      <sentence a="3" b="4">
+      c
+      </sentence>
+      </text>
+  output:
+    stdout: *input-1
+
+- name: 'vrt-drop-attrs: No changes: non-matching attribute and/or structure names or only --keep'
+  input:
+    cmdline:
+    - vrt-drop-attrs --drop="d,_.*"
+    - vrt-drop-attrs --structure=paragraph --drop="a,b"
+    - vrt-drop-attrs --drop="d,_.*" --structure=paragraph --drop="a,b"
+    - vrt-drop-attrs --keep="a,b,c"
+    stdin: *input-1
+  output:
+    stdout: *input-1
+  transform: &transform-comma-space
+  - name: attrlist with spaces
+    input:
+      cmdline:
+        replace: '/,/ /'
+
+
+- name: 'vrt-drop-attrs: Global --drop'
+  input:
+    cmdline: vrt-drop-attrs --drop="a"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" b="a" c="d">
+      <sentence z="_" b="1">
+      a
+      </sentence>
+      </text>
+      <text b="z" c="x">
+      <sentence b="2">
+      b
+      </sentence>
+      <sentence b="4">
+      c
+      </sentence>
+      </text>
+
+- name: 'vrt-drop-attrs: Global --drop, multiple attrs'
+  input:
+    cmdline: vrt-drop-attrs --drop="a,b,c"
+    stdin: *input-1
+  output:
+    stdout: &output-1yz |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_">
+      <sentence z="_">
+      a
+      </sentence>
+      </text>
+      <text>
+      <sentence>
+      b
+      </sentence>
+      <sentence>
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop, regexp'
+  input:
+    cmdline: vrt-drop-attrs --drop="[a-c].*"
+    stdin: *input-1
+  output:
+    stdout: *output-1yz
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop, multiple regexps'
+  input:
+    cmdline: vrt-drop-attrs --drop="[ab].*,.*[c-x]"
+    stdin: *input-1
+  output:
+    stdout: *output-1yz
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop, regexp matches all'
+  input:
+    cmdline: vrt-drop-attrs --drop=".*"
+    stdin: *input-1
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text>
+      <sentence>
+      a
+      </sentence>
+      </text>
+      <text>
+      <sentence>
+      b
+      </sentence>
+      <sentence>
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop, regexp fullmatch'
+  input:
+    cmdline: vrt-drop-attrs --drop="[a-c]"
+    stdin: &input-2 |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d" de="e" _fg="f">
+      <sentence z="_" a="0" b="1" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x" de="w" _fg="v">
+      <sentence a="1" b="2" cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6" a="3" b="4">
+      c
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" de="e" _fg="f">
+      <sentence z="_" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text de="w" _fg="v">
+      <sentence cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop, regexp, multi-char attrs'
+  input:
+    cmdline: vrt-drop-attrs --drop=".*[bdf].*"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" c="d">
+      <sentence z="_" a="0">
+      a
+      </sentence>
+      </text>
+      <text a="y" c="x">
+      <sentence a="1">
+      b
+      </sentence>
+      <sentence a="3">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+
+- name: 'vrt-drop-attrs: Global --drop regexp, --keep excepting'
+  input:
+    cmdline: vrt-drop-attrs --drop=".*[bdf].*" --keep="_.*"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" c="d" _fg="f">
+      <sentence z="_" a="0" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" c="x" _fg="v">
+      <sentence a="1" _fg="4">
+      b
+      </sentence>
+      <sentence _fg="6" a="3">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop regexp, --keep multiple'
+  input:
+    cmdline: vrt-drop-attrs --drop=".*[bdf].*" --keep="b,de"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d" de="e">
+      <sentence z="_" a="0" b="1">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x" de="w">
+      <sentence a="1" b="2">
+      b
+      </sentence>
+      <sentence a="3" b="4">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Global --drop regexp, --keep all'
+  input:
+    cmdline: vrt-drop-attrs --drop=".*[bdf].*" --keep=".*"
+    stdin: *input-2
+  output:
+    stdout: *input-2
+  transform: *transform-comma-space
+
+
+- name: 'vrt-drop-attrs: Structure-specific --drop'
+  input:
+    cmdline: vrt-drop-attrs --structure=sentence --drop="[a-c]"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d" de="e" _fg="f">
+      <sentence z="_" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x" de="w" _fg="v">
+      <sentence cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --drop and --keep'
+  input:
+    cmdline: vrt-drop-attrs --structure=sentence --drop=".*[bdf].*" --keep="_.*"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d" de="e" _fg="f">
+      <sentence z="_" a="0" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x" de="w" _fg="v">
+      <sentence a="1" _fg="4">
+      b
+      </sentence>
+      <sentence _fg="6" a="3">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --drop and --keep, two structures'
+  input:
+    cmdline: vrt-drop-attrs --structure=text --drop="..+" --keep="de" --structure=sentence --drop=".*[bdf].*" --keep="_.*"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" a="b" b="a" c="d" de="e">
+      <sentence z="_" a="0" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" c="x" de="w">
+      <sentence a="1" _fg="4">
+      b
+      </sentence>
+      <sentence _fg="6" a="3">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --drop overrides global'
+  input:
+    cmdline: vrt-drop-attrs --drop="a,b,c" --structure=sentence --drop=".*[bdf].*"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" de="e" _fg="f">
+      <sentence z="_" a="0">
+      a
+      </sentence>
+      </text>
+      <text de="w" _fg="v">
+      <sentence a="1">
+      b
+      </sentence>
+      <sentence a="3">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --keep'
+  input:
+    cmdline: vrt-drop-attrs --drop="." --structure=sentence --keep="a,b"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text de="e" _fg="f">
+      <sentence a="0" b="1" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text de="w" _fg="v">
+      <sentence a="1" b="2" cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6" a="3" b="4">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --keep overrides global'
+  input:
+    cmdline: vrt-drop-attrs --drop="." --keep="a,b" --structure=sentence --keep="b,z"
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="b" b="a" de="e" _fg="f">
+      <sentence z="_" b="1" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text a="y" b="z" de="w" _fg="v">
+      <sentence b="2" cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6" b="4">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space
+
+- name: 'vrt-drop-attrs: Structure-specific --drop, global --keep'
+  input:
+    cmdline: vrt-drop-attrs --keep="b" --structure=text --drop="a,b" --structure=sentence --drop="."
+    stdin: *input-2
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word -->
+      <text y="_" b="a" c="d" de="e" _fg="f">
+      <sentence b="1" cde="2" _fg="3">
+      a
+      </sentence>
+      </text>
+      <text b="z" c="x" de="w" _fg="v">
+      <sentence b="2" cde="3" _fg="4">
+      b
+      </sentence>
+      <sentence cde="5" _fg="6" b="4">
+      c
+      </sentence>
+      </text>
+  transform: *transform-comma-space

--- a/vrt-tools/vrt-drop-attrs
+++ b/vrt-tools/vrt-drop-attrs
@@ -1,0 +1,18 @@
+#! /usr/bin/env python3
+# -*- mode: Python; -*-
+
+"""
+vrt-drop-attrs
+
+A VRT tool to remove structural attributes (annotations) whose names
+match specified regular expressions.
+
+The actual implementation is in libvrt.tools.vrt_drop_attrs.
+"""
+
+
+from libvrt.tools.vrt_drop_attrs import VrtStructAttrDropper
+
+
+if __name__ == '__main__':
+    VrtStructAttrDropper().run()


### PR DESCRIPTION
Add `vrt-drop-attrs`, a VRT tool to drop (remove) the structural attributes (annotations) in the input VRT whose name matches a specified regular expression.

Usage:

```
usage: vrt-drop-attrs [-h] [--out file | --in-place | --backup bak | --in-sibling EXT] [--version]
                      [--verbose] [--structure struct] [--drop attr-regex-list]
                      [--keep attr-regex-list]
                      [file]

Drop (remove) the structural attributes (annotations) in the input VRT whose name matches a
specified regular expression.

positional arguments:
  file                  input file (default stdin)

options:
  [… Standard VRT tool options …]
  --verbose, -v         output to stderr the number of attributes dropped by structure
  --structure struct, --element struct, -e struct
                        the options following this (up to the next --structure) apply to
                        structures struct

structure-specific options:
  The following options can be specified multiple times: each occurrence applies to the
  --structure after which it is specified. If an option is specified before any --structure, it
  becomes the default for all structures.

  --drop attr-regex-list
                        drop attributes whose names fully match a regular expression in attr-
                        regex-list (separated by commas or spaces) and are not matched by a
                        regular expression specified with --keep
  --keep attr-regex-list
                        keep attributes whose names fully match a regular expression in attr-
                        regex-list even if they were matched by a regular expression specified
                        with --drop
```

The mechanism for specifying structure-specific options is the same as in `vrt-add-id`, using [`libvrt.groupargs`](https://github.com/CSCfi/Kielipankki-utilities/blob/master/vrt-tools/libvrt/groupargs.py) (see #13).

In addition, the pull request makes a minor change to the internals of the library module `libvrt.metaline` and adds or modifies some tests for the module.

Tests are included for the script.