### PR TITLE
Add `vrt-augment-name-attrs`: Add `ne` structures based on NER attributes

### DIFF
--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -276,9 +276,11 @@ class VrtNameAttrAugmenter(InputProcessor):
                     # Inside a name
                     if ml.isendtag(line) and ml.element(line) == b'sentence':
                         # Names may not cross sentence boundaries
-                        self.warn(f'No NER end tag for {nertag.decode("utf-8")}'
-                                  ' within sentence',
-                                  filename=inf.name, linenr=linenum + 1)
+                        self.warn(
+                            'No NER end tag for '
+                            + name_tokens[0][attrnum_nertag].decode('utf-8')
+                            + ' within sentence',
+                            filename=inf.name, linenr=linenum + 1)
                         ouf.writelines(namelines)
                         ouf.write(line)
                         namelines = []

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -9,7 +9,6 @@ Please run "vrt-augment-name-attrs -h" for more information.
 
 
 # TODO:
-# - Add options for positional attribute names
 # - Add nested ne tags for nested names (optionally?)
 # - Try to improve intra-name tag nesting in cases such as: "<tag>
 #   nameword1 </tag> nameword2", now tagged as "<tag> <ne> nameword1
@@ -22,6 +21,7 @@ import re
 
 from libvrt import metaline as ml
 from libvrt import nameline as nl
+from libvrt.argtypes import encode_utf8
 
 from vrtargsoolib import InputProcessor
 
@@ -31,10 +31,16 @@ class VrtNameAttrAugmenter(InputProcessor):
     """Class implementing vrt-augment-name-attrs functionality."""
 
     DESCRIPTION = """
-    Augment VRT input containing positional name attributes (nertag2)
+    Augment VRT input containing positional name attributes
     with <ne> structures with attributes.
     """
     ARGSPECS = [
+        ('--word = attr:encode_utf8 "word"',
+         '''positional attribute name for word form is attr'''),
+        ('--lemma = attr:encode_utf8 "lemma"',
+         '''positional attribute name for base form (lemma) is attr'''),
+        ('--nertag = attr:encode_utf8 "nertag2"',
+         '''positional attribute name for maximal NER tag is attr'''),
     ]
 
     def __init__(self):
@@ -128,15 +134,16 @@ class VrtNameAttrAugmenter(InputProcessor):
                         # Positional-attributes comment not yet seen
                         if nl.isnameline(line):
                             attrs = nl.parsenameline(line)
-                            for attrname in [b'nertag2', b'lemma', b'word']:
+                            for attrname in [
+                                    args.nertag, args.lemma, args.word]:
                                 if attrname not in attrs:
                                     self.error_exit(
                                         'No positional attribute \''
                                         + attrname.decode('utf-8')
                                         + '\' in input')
-                            attrnum_nertag = attrs.index(b'nertag2')
-                            attrnum_word = attrs.index(b'word')
-                            attrnum_lemma = attrs.index(b'lemma')
+                            attrnum_nertag = attrs.index(args.nertag)
+                            attrnum_word = attrs.index(args.word)
+                            attrnum_lemma = attrs.index(args.lemma)
                     ouf.write(line)
             elif attrnum_nertag is None:
                 # Token line, no positional-attributes comment seen

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -1,0 +1,161 @@
+
+"""
+vrt_augment_name_attrs.py
+
+The actual implementation of vrt-augment-name-attrs.
+
+Please run "vrt-augment-name-attrs -h" for more information.
+"""
+
+
+# TODO:
+# - Handle intra-name tags and comments
+# - Add options for positional attribute names
+# - Add nested ne tags for nested names (optionally?)
+
+
+import sys
+import re
+
+from libvrt import metaline as ml
+from libvrt import nameline as nl
+
+from vrtargsoolib import InputProcessor
+
+
+class VrtNameAttrAugmenter(InputProcessor):
+
+    """Class implementing vrt-augment-name-attrs functionality."""
+
+    DESCRIPTION = """
+    Augment VRT input containing positional name attributes (nertag2)
+    with <ne> structures with attributes.
+    """
+    ARGSPECS = [
+    ]
+
+    def __init__(self):
+        # extra_types=... is needed for using module-level functions
+        # as types in ARGSPECS (otherwise, type could be passed via a
+        # dict)
+        super().__init__(extra_types=globals())
+
+    def check_args(self, args):
+        """Check and modify `args` (parsed command line arguments)."""
+        self.args = args
+
+    def main(self, args, inf, ouf):
+        """Read `inf`, write to `ouf`, with command-line arguments `args`."""
+
+        # Index of the positional attribute for nertag, word and lemma
+        attrnum_nertag = attrnum_word = attrnum_lemma = None
+        # The type of a NER tag based on the last character of the
+        # value
+        NERTAG_NONE = b'_'[0]
+        NERTAG_BEGIN = b'B'[0]
+        NERTAG_END = b'E'[0]
+        NERTAG_FULL = b'F'[0]
+
+        def add_ne_tags(nertag, namelines, name_tokens):
+            """Return `namelines` surrounded by an <ne> structure.
+
+            `nertag` is the tag for the name and `name_tokens` is
+            `namelines` split into attributes.
+            """
+            # print('add_ne_tags', nertag, namelines, name_tokens, file=sys.stderr)
+            return (
+                [ml.starttag(
+                    b'ne', make_ne_attrs(nertag, name_tokens))]
+                + namelines
+                + [b'</ne>\n'])
+
+        def make_ne_attrs(nertag, name_tokens):
+            """Return attribute (name, value) pairs for <ne> structure.
+
+            Return structural attributes for `nertag` and `name_tokens`
+            """
+            mo = re.match(rb'((?:Ena|Nu|Ti)mex)(...)(...)', nertag)
+            is_placename = mo.group(2) == b'Loc'
+            name = make_name(name_tokens, mo.group(1)).replace(b'"', b'&quot;')
+            return (
+                (b'name', name),
+                (b'fulltype', mo.group(0)),
+                *((attrname, mo.group(group + 1).upper())
+                  for group, attrname in enumerate(
+                          (b'ex', b'type', b'subtype'))),
+                (b'placename', name if is_placename else b''),
+                (b'placename_source', b'ner' if is_placename else b''))
+
+        def make_name(name_tokens, name_cat):
+            """Return a name composed of `name_tokens`, of type `name_cat`."""
+            if name_cat in (b'Timex', b'Numex'):
+                # For temporal and numeric expressions, return a
+                # concatenation of word forms
+                return b' '.join(
+                    token[attrnum_word] for token in name_tokens)
+            else:
+                # For name expressions proper, use lemma of the last
+                # token and word forms of the preceding ones
+                last_wordform = name_tokens[-1][attrnum_word]
+                last_lemma = name_tokens[-1][attrnum_lemma]
+                # If the last word form is capitalized or
+                # all-uppercase, make the last lemma such, too
+                if last_wordform.istitle():
+                    last_lemma = last_lemma.title()
+                elif last_wordform.isupper():
+                    last_lemma = last_lemma.upper()
+                return b' '.join([token[attrnum_word]
+                                  for token in name_tokens[:-1]]
+                                 + [last_lemma])
+
+        # Input lines within a (multi-word) name
+        namelines = []
+        # namelines split into attributes, to avoid to splitting
+        # multiple times
+        name_tokens = []
+        for line in inf:
+            if ml.ismeta(line):
+                # Structure or comment line
+                if attrnum_nertag is None:
+                    # Positional-attributes comment not yet seen
+                    if nl.isnameline(line):
+                        attrs = nl.parsenameline(line)
+                        for attrname in [b'nertag2', b'lemma', b'word']:
+                            if attrname not in attrs:
+                                self.error_exit(
+                                    'No positional attribute \''
+                                    + attrname.decode('utf-8')
+                                    + '\' in input')
+                        attrnum_nertag = attrs.index(b'nertag2')
+                        attrnum_word = attrs.index(b'word')
+                        attrnum_lemma = attrs.index(b'lemma')
+                ouf.write(line)
+            elif attrnum_nertag is None:
+                # Token line, no positional-attributes comment seen
+                self.error_exit(
+                    'No positional-attributes comment before the first token')
+            else:
+                # Token line
+                attrs = line[:-1].split(b'\t')
+                nertag = attrs[attrnum_nertag]
+                nertag_type = nertag[-1]
+                if namelines:
+                    # Within a multi-word name
+                    namelines.append(line)
+                    name_tokens.append(attrs)
+                    if nertag_type == NERTAG_END:
+                        # Last token of the name
+                        ouf.writelines(
+                            add_ne_tags(nertag, namelines, name_tokens))
+                        namelines = []
+                        name_tokens = []
+                elif nertag_type == NERTAG_NONE:
+                    # Not a name
+                    ouf.write(line)
+                elif nertag_type == NERTAG_FULL:
+                    # Single-word name
+                    ouf.writelines(add_ne_tags(nertag, [line], [attrs]))
+                elif nertag_type == NERTAG_BEGIN:
+                    # Begin a multi-word name
+                    namelines.append(line)
+                    name_tokens.append(attrs)

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -124,7 +124,7 @@ class VrtNameAttrAugmenter(InputProcessor):
             # nameline_index[i] is the number of the line in namelines
             # whose number was i in the input namelines but which may
             # be different after adding <ne> tags
-            nameline_index = list(range(len(namelines)))
+            nameline_index = list(range(len(namelines) + 1))
             for depth in range(maxdepth, 0, -1):
                 for nameinfo in nested_names[depth - 1]:
                     nertag, start, end = nameinfo

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -252,7 +252,7 @@ class VrtNameAttrAugmenter(InputProcessor):
             input file name (or ``<stdin>``) and input line number
             `linenum`.
             """
-            self.warn(msg + ': "' + nertag.decode('utf-8') + '"',
+            self.warn(msg + ': ' + nertag.decode('utf-8'),
                       filename=inf.name, linenr=linenum + 1)
 
         def set_attrnums(line):

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -276,11 +276,9 @@ class VrtNameAttrAugmenter(InputProcessor):
                     # Inside a name
                     if ml.isendtag(line) and ml.element(line) == b'sentence':
                         # Names may not cross sentence boundaries
-                        self.warn(
-                            'No NER end tag for '
-                            + name_tokens[0][attrnum_nertag].decode('utf-8')
-                            + ' within sentence',
-                            filename=inf.name, linenr=linenum + 1)
+                        warn('NER start tag without end tag within sentence',
+                             name_tokens[0][attrnum_nertag],
+                             linenum - len(namelines))
                         ouf.writelines(namelines)
                         ouf.write(line)
                         namelines = []

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -127,14 +127,17 @@ class VrtNameAttrAugmenter(InputProcessor):
             # Names by nesting depth
             nested_names = defaultdict(list)
             maxdepth = 0
+            # Line number of namelines[0]
+            linenum1 = linenum - len(namelines) + 1
             for token_num, token in enumerate(name_tokens):
+                token_linenum = linenum1 + token_num
                 nertags = token[attrnum_nertags].strip(b'|').split(b'|')
                 for nertag in nertags:
                     if not nertag:
                         continue
                     nertag_parts = split_nertag(nertag)
                     if not nertag_parts or not nertag_parts['depth']:
-                        warn('Invalid nested NER tag', nertag, linenum)
+                        warn('Invalid nested NER tag', nertag, token_linenum)
                         continue
                     depth = int(nertag_parts['depth'])
                     # Ignore depth 0 (top level)
@@ -155,7 +158,7 @@ class VrtNameAttrAugmenter(InputProcessor):
                                 warn('Nested NER tag '
                                      + depth_names[-1][0].decode('utf-8')
                                      + f' already open at level {depth}',
-                                     nertag, linenum)
+                                     nertag, token_linenum)
                         elif tagtype == NERTAG_END:
                             open_name = depth_names[-1]
                             if (nertag_parts['fulltype']
@@ -164,7 +167,7 @@ class VrtNameAttrAugmenter(InputProcessor):
                             else:
                                 warn('Nested NER end tag does not match start'
                                      ' tag ' + open_name[0].decode('utf-8'),
-                                     nertag, linenum)
+                                     nertag, token_linenum)
                         else:
                             warn('Invalid nested NER tag', nertag, linenum)
             # nameline_index[i] is the number of the line in namelines
@@ -175,7 +178,7 @@ class VrtNameAttrAugmenter(InputProcessor):
                 for nameinfo in nested_names[depth - 1]:
                     if len(nameinfo) < 4:
                         warn('No end tag for nested NER tag', nameinfo[0],
-                             linenum)
+                             linenum1 + nameinfo[2])
                         continue
                     _, nertag_parts, start, end = nameinfo
                     nameline_start = nameline_index[start]

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -203,6 +203,24 @@ class VrtNameAttrAugmenter(InputProcessor):
             self.warn(msg + ': "' + nertag.decode('utf-8') + '"',
                       filename=inf.name, linenr=linenum + 1)
 
+        def set_attrnums(line):
+            """Set `attrnum_*` variables from pos attrs comment `line`."""
+            nonlocal attrnum_nertag, attrnum_nertags
+            nonlocal attrnum_word, attrnum_lemma
+            attrs = nl.parsenameline(line)
+            attrnames_check = [args.nertag, args.lemma, args.word]
+            if not args.maximal_only:
+                attrnames_check.append(args.multi_nertag)
+            for attrname in attrnames_check:
+                if attrname not in attrs:
+                    self.error_exit('No positional attribute \''
+                                    + attrname.decode('utf-8') + '\' in input')
+            attrnum_nertag = attrs.index(args.nertag)
+            attrnum_word = attrs.index(args.word)
+            attrnum_lemma = attrs.index(args.lemma)
+            if not args.maximal_only:
+                attrnum_nertags = attrs.index(args.multi_nertag)
+
         # Input lines within a (multi-word) name
         namelines = []
         # namelines (tokens) split into attributes, to avoid to
@@ -219,22 +237,7 @@ class VrtNameAttrAugmenter(InputProcessor):
                     if attrnum_nertag is None:
                         # Positional-attributes comment not yet seen
                         if nl.isnameline(line):
-                            attrs = nl.parsenameline(line)
-                            attrnames_check = [
-                                args.nertag, args.lemma, args.word]
-                            if not args.maximal_only:
-                                attrnames_check.append(args.multi_nertag)
-                            for attrname in attrnames_check:
-                                if attrname not in attrs:
-                                    self.error_exit(
-                                        'No positional attribute \''
-                                        + attrname.decode('utf-8')
-                                        + '\' in input')
-                            attrnum_nertag = attrs.index(args.nertag)
-                            attrnum_word = attrs.index(args.word)
-                            attrnum_lemma = attrs.index(args.lemma)
-                            if not args.maximal_only:
-                                attrnum_nertags = attrs.index(args.multi_nertag)
+                            set_attrnums(line)
                     ouf.write(line)
             elif attrnum_nertag is None:
                 # Token line, no positional-attributes comment seen

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -39,7 +39,9 @@ class VrtNameAttrAugmenter(InputProcessor):
         ('--word = attr:encode_utf8 "word"',
          '''positional attribute name for word form is attr'''),
         ('--lemma = attr:encode_utf8 "lemma"',
-         '''positional attribute name for base form (lemma) is attr'''),
+         '''positional attribute name for base form (lemma) is attr;
+            if the input does not contain attr, use word forms in the
+            place of lemmas (specify "" to suppress a warning)'''),
         ('--nertag = attr:encode_utf8 "nertag2"',
          '''positional attribute name for maximal NER tag is attr'''),
         ('--multi-nertag = attr:encode_utf8 "nertags2"',
@@ -235,7 +237,7 @@ class VrtNameAttrAugmenter(InputProcessor):
             nonlocal attrnum_nertag, attrnum_nertags
             nonlocal attrnum_word, attrnum_lemma
             attrs = nl.parsenameline(line)
-            attrnames_check = [args.nertag, args.lemma, args.word]
+            attrnames_check = [args.nertag, args.word]
             if not args.maximal_only:
                 attrnames_check.append(args.multi_nertag)
             for attrname in attrnames_check:
@@ -244,7 +246,14 @@ class VrtNameAttrAugmenter(InputProcessor):
                                     + attrname.decode('utf-8') + '\' in input')
             attrnum_nertag = attrs.index(args.nertag)
             attrnum_word = attrs.index(args.word)
-            attrnum_lemma = attrs.index(args.lemma)
+            if args.lemma in attrs:
+                attrnum_lemma = attrs.index(args.lemma)
+            else:
+                if args.lemma:
+                    self.warn('No positional attribute \''
+                              + args.lemma.decode('utf-8') + '\' in input;'
+                              ' using word forms in the place of lemmas')
+                attrnum_lemma = attrnum_word
             if not args.maximal_only:
                 attrnum_nertags = attrs.index(args.multi_nertag)
 

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -136,10 +136,11 @@ class VrtNameAttrAugmenter(InputProcessor):
                         tagtype = nertag_parts['kind'][0]
                         if tagtype == NERTAG_FULL:
                             nested_names[depth - 1].append(
-                                [nertag_parts, token_num, token_num + 1])
+                                [nertag, nertag_parts, token_num,
+                                 token_num + 1])
                         elif tagtype == NERTAG_BEGIN:
                             nested_names[depth - 1].append(
-                                [nertag_parts, token_num])
+                                [nertag, nertag_parts, token_num])
                         elif tagtype == NERTAG_END:
                             nested_names[depth - 1][-1].append(token_num + 1)
                         else:
@@ -150,7 +151,11 @@ class VrtNameAttrAugmenter(InputProcessor):
             nameline_index = list(range(len(namelines) + 1))
             for depth in range(maxdepth, 0, -1):
                 for nameinfo in nested_names[depth - 1]:
-                    nertag_parts, start, end = nameinfo
+                    if len(nameinfo) < 4:
+                        warn('No end tag for nested NER tag', nameinfo[0],
+                             linenum)
+                        continue
+                    _, nertag_parts, start, end = nameinfo
                     nameline_start = nameline_index[start]
                     nameline_end = nameline_index[end]
                     namelines[nameline_start:nameline_end] = (

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -32,8 +32,13 @@ class VrtNameAttrAugmenter(InputProcessor):
     """Class implementing vrt-augment-name-attrs functionality."""
 
     DESCRIPTION = """
-    Augment VRT input containing positional name attributes
-    with <ne> structures with attributes.
+    Augment VRT input containing positional name attributes with <ne>
+    structures with attributes. The tool expects a positional
+    attribute to contain NER tags for maximal names, matching the
+    regular expression "(Ena|Nu|Ti)mex[A-Z][a-z]+[A-Z][a-z]+-[BEF]",
+    as produced by vrt-finnish-nertag. Another attribute can contain a
+    set of NER tags for possible nested names, with "-N" appended
+    where N is the nesting level.
     """
     ARGSPECS = [
         ('--word = attr:encode_utf8 "word"',

--- a/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
+++ b/vrt-tools/libvrt/tools/vrt_augment_name_attrs.py
@@ -247,7 +247,7 @@ class VrtNameAttrAugmenter(InputProcessor):
                 # Token line
                 attrs = line[:-1].split(b'\t')
                 nertag = attrs[attrnum_nertag]
-                nertag_type = nertag[-1] if nertag else b''
+                nertag_type = nertag[-1] if nertag else NERTAG_NONE
                 if namelines:
                     # Within a multi-word name
                     namelines.append(line)

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -1070,3 +1070,34 @@
       </ne>
       </sentence>
       </text>
+
+- name: 'vrt-augment-name-attrs: Two-level name with each word as a complete name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Euroopan	Eurooppa	EnamexLocPpl-B	|EnamexLocPpl-B-0|EnamexLocPpl-F-1|	B-LOC
+      Suomen	Suomi	_	|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	I-LOC
+      Turussa	Turku	EnamexLocPpl-E	|EnamexLocPpl-E-0|EnamexLocPpl-E-1|EnamexLocPpl-F-2|	I-LOC
+      </sentence>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Euroopan Suomen Turku" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Euroopan Suomen Turku" placename_source="ner">
+      <ne name="Eurooppa" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Eurooppa" placename_source="ner">
+      Euroopan	Eurooppa	EnamexLocPpl-B	|EnamexLocPpl-B-0|EnamexLocPpl-F-1|	B-LOC
+      </ne>
+      <ne name="Suomen Turku" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Suomen Turku" placename_source="ner">
+      <ne name="Suomi" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Suomi" placename_source="ner">
+      Suomen	Suomi	_	|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	I-LOC
+      </ne>
+      <ne name="Turku" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Turku" placename_source="ner">
+      Turussa	Turku	EnamexLocPpl-E	|EnamexLocPpl-E-0|EnamexLocPpl-E-1|EnamexLocPpl-F-2|	I-LOC
+      </ne>
+      </ne>
+      </ne>
+      </sentence>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -206,9 +206,9 @@
   output:
     stdout: *input-sentence-breaks-name
     stderr: |
-      vrt-augment-name-attrs: <stdin>:5: Warning: No NER end tag for EnamexLocStr-B within sentence
+      vrt-augment-name-attrs: <stdin>:4: Warning: NER start tag without end tag within sentence: "EnamexLocStr-B"
       vrt-augment-name-attrs: <stdin>:7: Warning: NER end tag without start tag: "EnamexLocStr-E"
-      vrt-augment-name-attrs: <stdin>:12: Warning: No NER end tag for EnamexLocStr-B within sentence
+      vrt-augment-name-attrs: <stdin>:10: Warning: NER start tag without end tag within sentence: "EnamexLocStr-B"
 
 - name: 'vrt-augment-name-attrs: End of input at the middle of name'
   input:

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -1,0 +1,732 @@
+
+# scripttestlib tests for vrt-augment-name-attrs
+
+
+# Default input and output
+
+- defaults:
+    output:
+      # No errors
+      returncode: 0
+      stderr: ''
+
+
+# Defective input
+
+- name: 'vrt-augment-name-attrs: No positional-attributes comment'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <text a="b">
+      <sentence x="y">
+      a
+      </sentence>
+      </text>
+  output:
+    returncode: 1
+    stdout: |
+      <text a="b">
+      <sentence x="y">
+    stderr: |
+      vrt-augment-name-attrs: No positional-attributes comment before the first token
+
+- name: 'vrt-augment-name-attrs: No nertag2 attribute'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word -->
+      <text a="b">
+      <sentence x="y">
+      a
+      </sentence>
+      </text>
+  output:
+    returncode: 1
+    stdout: ''
+    stderr: |
+      vrt-augment-name-attrs: No positional attribute 'nertag2' in input
+
+- name: 'vrt-augment-name-attrs: No lemma attribute'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word nertag2 -->
+      <text a="b">
+      <sentence x="y">
+      a	_
+      </sentence>
+      </text>
+  output:
+    returncode: 1
+    stdout: ''
+    stderr: |
+      vrt-augment-name-attrs: No positional attribute 'lemma' in input
+
+- name: 'vrt-augment-name-attrs: No word attribute'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: lemma nertag2 -->
+      <text a="b">
+      <sentence x="y">
+      a	_
+      </sentence>
+      </text>
+  output:
+    returncode: 1
+    stdout: ''
+    stderr: |
+      vrt-augment-name-attrs: No positional attribute 'word' in input
+
+
+# No names
+
+- name: 'vrt-augment-name-attrs: No names, output intact'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: &input-no-names |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      A	a	_	|	O
+      on	olla	_	|	O
+      alussa	alku	_	|	O
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: *input-no-names
+
+
+# Single-word names
+
+- name: 'vrt-augment-name-attrs: Single-word names, nothing else'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+      A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+      Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="01.06.2001" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
+      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+      </ne>
+      <ne name="1.07" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
+      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+      </ne>
+      <ne name="A100" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+      </ne>
+      <ne name="Aaltonen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Single-word names, non-name tokens'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      On	olla	_	|	O
+      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+      aika	aika	_	|	O
+      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      On	olla	_	|	O
+      <ne name="01.06.2001" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
+      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+      </ne>
+      aika	aika	_	|	O
+      <ne name="1.07" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
+      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+      </ne>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Single-word names, different attr order, extra attrs'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: id word nerbio2 nertag2 nertags2/ x lemma -->
+      <text a="b">
+      <sentence x="y">
+      1	On	O	_	|	x	olla
+      2	01.06.2001	B-DATE	TimexTmeDat-F	|TimexTmeDat-F-0|	y	01.06.2001
+      3	aika	O	_	|	z	aika
+      4	1.07	B-MISC	TimexTmeHrm-F	|TimexTmeHrm-F-0|	z	1.07
+      5	.	O	_	|	z	.
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: id word nerbio2 nertag2 nertags2/ x lemma -->
+      <text a="b">
+      <sentence x="y">
+      1	On	O	_	|	x	olla
+      <ne name="01.06.2001" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
+      2	01.06.2001	B-DATE	TimexTmeDat-F	|TimexTmeDat-F-0|	y	01.06.2001
+      </ne>
+      3	aika	O	_	|	z	aika
+      <ne name="1.07" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
+      4	1.07	B-MISC	TimexTmeHrm-F	|TimexTmeHrm-F-0|	z	1.07
+      </ne>
+      5	.	O	_	|	z	.
+      </sentence>
+      </text>
+
+
+# Multi-word names
+
+- name: 'vrt-augment-name-attrs: Multi-word names, no nesting'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      0,25	0,25	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      litraa	litra	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      Aamuruskontie	aamuruskotie	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      6	6	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      Äänikortti	äänikortti	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Sound	Sound	_	|	I-PRO
+      Blaster	Blaster	_	|	I-PRO
+      Live	live	_	|	I-PRO
+      1024	1024	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      Adrian	Adrian	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Erlandsson	Erlandsson	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      Agia	Agia	EnamexLocPpl-B	|EnamexLocPpl-B-0|	B-LOC
+      Napa	napa	EnamexLocPpl-E	|EnamexLocPpl-E-0|	I-LOC
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="0,25 litraa" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
+      0,25	0,25	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      litraa	litra	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      <ne name="Aamuruskontie 6" fulltype="EnamexLocStr" ex="ENAMEX" type="LOC" subtype="STR" placename="Aamuruskontie 6" placename_source="ner">
+      Aamuruskontie	aamuruskotie	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      6	6	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      </ne>
+      <ne name="Äänikortti Sound Blaster Live 1024" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      Äänikortti	äänikortti	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Sound	Sound	_	|	I-PRO
+      Blaster	Blaster	_	|	I-PRO
+      Live	live	_	|	I-PRO
+      1024	1024	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      <ne name="Adrian Erlandsson" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Adrian	Adrian	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Erlandsson	Erlandsson	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="Agia Napa" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Agia Napa" placename_source="ner">
+      Agia	Agia	EnamexLocPpl-B	|EnamexLocPpl-B-0|	B-LOC
+      Napa	napa	EnamexLocPpl-E	|EnamexLocPpl-E-0|	I-LOC
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Inflected or case-changed names'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      0,1	0,1	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      grammaa	gramma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      10.	10.	TimexTmeDat-B	|TimexTmeDat-B-0|	B-DATE
+      kesäkuuta	kesäkuu	TimexTmeDat-E	|TimexTmeDat-E-0|	I-DATE
+      Ahteesta	ahde	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      Ahteen	ahde	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Mattikin	matti	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      Ahti	Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	Karjalainen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      6th	6th	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      Avenue	avenue	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      AAMOS	Aamos	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      Ruusu	ruusu	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Olit	olla	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      Ruotsalaisen	ruotsalainen	EnamexOrgTvr-B	|EnamexOrgTvr-B-0|	B-ORG
+      Bilsport	Bilsport	_	|	I-ORG
+      -lehden	lehti	EnamexOrgTvr-E	|EnamexOrgTvr-E-0|	I-ORG
+      RUOKKIMAAN	ruokkimaa	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      KONETTA	kone	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="0,1 grammaa" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
+      0,1	0,1	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      grammaa	gramma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      <ne name="10. kesäkuuta" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
+      10.	10.	TimexTmeDat-B	|TimexTmeDat-B-0|	B-DATE
+      kesäkuuta	kesäkuu	TimexTmeDat-E	|TimexTmeDat-E-0|	I-DATE
+      </ne>
+      <ne name="Ahde" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahteesta	ahde	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      </ne>
+      <ne name="Ahteen Matti" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahteen	ahde	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Mattikin	matti	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="Ahti Karjalainen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahti	Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	Karjalainen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="6th Avenue" fulltype="EnamexLocStr" ex="ENAMEX" type="LOC" subtype="STR" placename="6th Avenue" placename_source="ner">
+      6th	6th	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      Avenue	avenue	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      </ne>
+      <ne name="Aaltosen taidemuseo" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      </ne>
+      <ne name="AAMOS" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      AAMOS	Aamos	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+      </ne>
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      <ne name="Ruusu Olla" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ruusu	ruusu	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Olit	olla	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="Ruotsalaisen Bilsport lehti" fulltype="EnamexOrgTvr" ex="ENAMEX" type="ORG" subtype="TVR" placename="" placename_source="">
+      Ruotsalaisen	ruotsalainen	EnamexOrgTvr-B	|EnamexOrgTvr-B-0|	B-ORG
+      Bilsport	Bilsport	_	|	I-ORG
+      -lehden	lehti	EnamexOrgTvr-E	|EnamexOrgTvr-E-0|	I-ORG
+      </ne>
+      <ne name="RUOKKIMAAN KONE" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      RUOKKIMAAN	ruokkimaa	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      KONETTA	kone	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Names with XML character references'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Aake	Aake	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      &amp;	&amp;	_	|	I-ORG
+      Co	Co	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      &lt;1500	&lt;1500	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      kg	kg	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      Saab	Saab	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      9000	9000	_	|	I-PRO
+      170hp-&gt;235hp	170hp-&gt;235hp	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Aake &amp; Co" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Aake	Aake	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      &amp;	&amp;	_	|	I-ORG
+      Co	Co	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      <ne name="&lt;1500 kg" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
+      &lt;1500	&lt;1500	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      kg	kg	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      <ne name="Saab 9000 170hp-&gt;235hp" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      Saab	Saab	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      9000	9000	_	|	I-PRO
+      170hp-&gt;235hp	170hp-&gt;235hp	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Names with double quotation marks'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      15"	15"	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      tuuman	tuuma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      15""	15""	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      tuuman	tuuma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="15&quot; tuuman" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
+      15"	15"	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      tuuman	tuuma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      <ne name="15&quot;&quot; tuuman" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
+      15""	15""	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
+      tuuman	tuuma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      </sentence>
+      </text>
+
+
+# Intra-sentence tags
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence comments'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <!-- Comment before -->
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      <!-- Comment middle -->
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      <!-- Comment after -->
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <!-- Comment before -->
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      <!-- Comment middle -->
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      <!-- Comment after -->
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure around name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <emph>
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </emph>
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <emph>
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </emph>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure covers first word of name'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <emph>
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      </emph>
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <emph>
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      </emph>
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure ends within name'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <emph>
+      oli	olla	_	|	O
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      </emph>
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <emph>
+      oli	olla	_	|	O
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      </emph>
+      Siistinä	siisti	_	|	I-ORG
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure covers last word of name'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      <emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </emph>
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      <emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </emph>
+      </ne>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure begins within name'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      <emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      .	.	_	|	O
+      </emph>
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      Siistinä	siisti	_	|	I-ORG
+      <emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      .	.	_	|	O
+      </emph>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure completely within name'
+  status: xfail:Intra-name tags not yet handled correctly
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      <emph>
+      Siistinä	siisti	_	|	I-ORG
+      </emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      .	.	_	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
+      <emph>
+      Siistinä	siisti	_	|	I-ORG
+      </emph>
+      ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      .	.	_	|	O
+      </sentence>
+      </text>
+
+
+# Multi-level names
+
+- name: 'vrt-augment-name-attrs: Two-level names'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      100	100	NumexMsrCur-B	|NumexMsrCur-B-0|	B-MISC
+      miljardia	miljardi	_	|	I-MISC
+      Suomen	Suomi	_	|EnamexLocPpl-F-1|	I-MISC
+      markkaa	markka	NumexMsrCur-E	|NumexMsrCur-E-0|	I-MISC
+      9.40	9.40	TimexTmeHrm-B	|TimexTmeHrm-B-0|	B-MISC
+      Keski-Euroopan	Keski-Euroopan	_	|EnamexLocPpl-F-1|	I-MISC
+      aikaa	aika	TimexTmeHrm-E	|TimexTmeHrm-E-0|	I-MISC
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      Adobe	Adobe	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      Acrobat	Acrobat	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      Agia	Agia	EnamexLocFnc-B	|EnamexLocFnc-B-0|EnamexLocPpl-B-1|	B-LOC
+      Napan	nappa	_	|EnamexLocPpl-E-1|	I-LOC
+      vesipuistossa	vesipuisto	EnamexLocFnc-E	|EnamexLocFnc-E-0|	I-LOC
+      Alfa	alfa	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-B-1|	B-PRO
+      Romeo	Romeo	_	|EnamexOrgCrp-E-1|	I-PRO
+      155	155	_	|	I-PRO
+      2.0 16V	2.0 16V	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="100 miljardia Suomen markkaa" fulltype="NumexMsrCur" ex="NUMEX" type="MSR" subtype="CUR" placename="" placename_source="">
+      100	100	NumexMsrCur-B	|NumexMsrCur-B-0|	B-MISC
+      miljardia	miljardi	_	|	I-MISC
+      Suomen	Suomi	_	|EnamexLocPpl-F-1|	I-MISC
+      markkaa	markka	NumexMsrCur-E	|NumexMsrCur-E-0|	I-MISC
+      </ne>
+      <ne name="9.40 Keski-Euroopan aikaa" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
+      9.40	9.40	TimexTmeHrm-B	|TimexTmeHrm-B-0|	B-MISC
+      Keski-Euroopan	Keski-Euroopan	_	|EnamexLocPpl-F-1|	I-MISC
+      aikaa	aika	TimexTmeHrm-E	|TimexTmeHrm-E-0|	I-MISC
+      </ne>
+      <ne name="Aaltosen taidemuseo" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      </ne>
+      <ne name="Adobe Acrobat" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      Adobe	Adobe	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      Acrobat	Acrobat	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      <ne name="Agia Napan vesipuisto" fulltype="EnamexLocFnc" ex="ENAMEX" type="LOC" subtype="FNC" placename="Agia Napan vesipuisto" placename_source="ner">
+      Agia	Agia	EnamexLocFnc-B	|EnamexLocFnc-B-0|EnamexLocPpl-B-1|	B-LOC
+      Napan	nappa	_	|EnamexLocPpl-E-1|	I-LOC
+      vesipuistossa	vesipuisto	EnamexLocFnc-E	|EnamexLocFnc-E-0|	I-LOC
+      </ne>
+      <ne name="Alfa Romeo 155 2.0 16V" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      Alfa	alfa	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-B-1|	B-PRO
+      Romeo	Romeo	_	|EnamexOrgCrp-E-1|	I-PRO
+      155	155	_	|	I-PRO
+      2.0 16V	2.0 16V	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Three-level names'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -186,6 +186,101 @@
     stderr: |
       vrt-augment-name-attrs: <stdin>:4: Warning: NER end tag without start tag: "EnamexPrsHum-E"
 
+- name: 'vrt-augment-name-attrs: Invalid NER begin and end tags within a name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <!-- This  is really produced by FiNER as of 2024-10-31 -->
+      <!-- if preceded by another name enclosed in double quotes. -->
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Green	Green	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      street	street	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      hooligans	hooligans	_	|	O
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <!-- This  is really produced by FiNER as of 2024-10-31 -->
+      <!-- if preceded by another name enclosed in double quotes. -->
+      <ne name="&quot; Green street hooligans &quot;" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Green	Green	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      street	street	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      hooligans	hooligans	_	|	O
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: "EnamexLocStr-B"
+      vrt-augment-name-attrs: <stdin>:8: Warning: NER end tag does not match start tag EnamexProXxx-B: "EnamexLocStr-E"
+
+- name: 'vrt-augment-name-attrs: Invalid NER begin and end tags within a multi-level name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <!-- These are artificial examples for testing purposes -->
+      <sentence x="1">
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Second	Second	_	|EnamexOrgClt-B-1|	I-PRO
+      Green	Green	_	|EnamexLocStr-B-1|	I-PRO
+      street	street	_	|EnamexLocStr-E-1|	I-PRO
+      hooligans	hooligans	_	|EnamexOrgClt-E-1|	I-PRO
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      <sentence x="2">
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Second	Second	_	|EnamexOrgClt-B-1|	I-PRO
+      Green	Green	_	|	I-PRO
+      street	street	_	|EnamexLocStr-E-1|	I-PRO
+      hooligans	hooligans	_	|EnamexOrgClt-E-1|	I-PRO
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <!-- These are artificial examples for testing purposes -->
+      <sentence x="1">
+      <ne name="&quot; Second Green street hooligans &quot;" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      <ne name="Second Green street hooligans" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      Second	Second	_	|EnamexOrgClt-B-1|	I-PRO
+      Green	Green	_	|EnamexLocStr-B-1|	I-PRO
+      street	street	_	|EnamexLocStr-E-1|	I-PRO
+      hooligans	hooligans	_	|EnamexOrgClt-E-1|	I-PRO
+      </ne>
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      <sentence x="2">
+      <ne name="&quot; Second Green street hooligans &quot;" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      "	"	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      <ne name="Second Green street hooligans" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      Second	Second	_	|EnamexOrgClt-B-1|	I-PRO
+      Green	Green	_	|	I-PRO
+      street	street	_	|EnamexLocStr-E-1|	I-PRO
+      hooligans	hooligans	_	|EnamexOrgClt-E-1|	I-PRO
+      </ne>
+      "	"	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:10: Warning: Nested NER tag EnamexOrgClt-B-1 already open at level 1: "EnamexLocStr-B-1"
+      vrt-augment-name-attrs: <stdin>:10: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
+      vrt-augment-name-attrs: <stdin>:18: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
+
 - name: 'vrt-augment-name-attrs: Name does not end within a sentence'
   input:
     cmdline: vrt-augment-name-attrs

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -87,18 +87,18 @@
   output:
     stdout: *input-invalid-nertag
     stderr: |
-      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag: "A"
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag: "1"
-      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag: "A-1"
-      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: "NamexFooBar-F"
-      vrt-augment-name-attrs: <stdin>:9: Warning: Invalid NER tag: "EnamexFoo-F"
-      vrt-augment-name-attrs: <stdin>:10: Warning: Invalid NER tag: "EnamexFB-F"
-      vrt-augment-name-attrs: <stdin>:11: Warning: Invalid NER tag: "ENAMEXPRSHUM-F"
-      vrt-augment-name-attrs: <stdin>:12: Warning: Invalid NER tag: "EnamexFo1Bo1-F"
-      vrt-augment-name-attrs: <stdin>:13: Warning: Invalid NER tag: "EnamexFooBarBaz-F"
-      vrt-augment-name-attrs: <stdin>:14: Warning: Invalid NER tag: "EnamexFooB-F"
-      vrt-augment-name-attrs: <stdin>:15: Warning: Invalid NER tag: "EnamexFBar-F"
-      vrt-augment-name-attrs: <stdin>:16: Warning: Invalid NER tag: "EnamexFoBo-G"
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag: A
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag: 1
+      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag: A-1
+      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: NamexFooBar-F
+      vrt-augment-name-attrs: <stdin>:9: Warning: Invalid NER tag: EnamexFoo-F
+      vrt-augment-name-attrs: <stdin>:10: Warning: Invalid NER tag: EnamexFB-F
+      vrt-augment-name-attrs: <stdin>:11: Warning: Invalid NER tag: ENAMEXPRSHUM-F
+      vrt-augment-name-attrs: <stdin>:12: Warning: Invalid NER tag: EnamexFo1Bo1-F
+      vrt-augment-name-attrs: <stdin>:13: Warning: Invalid NER tag: EnamexFooBarBaz-F
+      vrt-augment-name-attrs: <stdin>:14: Warning: Invalid NER tag: EnamexFooB-F
+      vrt-augment-name-attrs: <stdin>:15: Warning: Invalid NER tag: EnamexFBar-F
+      vrt-augment-name-attrs: <stdin>:16: Warning: Invalid NER tag: EnamexFoBo-G
 
 - name: 'vrt-augment-name-attrs: Invalid NER tags within a name'
   input:
@@ -131,9 +131,9 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag within name: "EnamexProXxx-B"
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag within name: "EnamexProXxx-F"
-      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: "1"
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag within name: EnamexProXxx-B
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag within name: EnamexProXxx-F
+      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: 1
 
 - name: 'vrt-augment-name-attrs: Invalid NER tags in multi-level NER attribute'
   input:
@@ -160,10 +160,10 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: "EnamexLocPpl-B-X"
-      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: "F-X-12"
-      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: "EnamexLocPpl-1"
-      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: "F-1"
+      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: EnamexLocPpl-B-X
+      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: F-X-12
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: EnamexLocPpl-1
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: F-1
 
 - name: 'vrt-augment-name-attrs: NER end tag without start tag'
   input:
@@ -184,7 +184,7 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:4: Warning: NER end tag without start tag: "EnamexPrsHum-E"
+      vrt-augment-name-attrs: <stdin>:4: Warning: NER end tag without start tag: EnamexPrsHum-E
 
 - name: 'vrt-augment-name-attrs: Invalid NER begin and end tags within a name'
   input:
@@ -219,8 +219,8 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: "EnamexLocStr-B"
-      vrt-augment-name-attrs: <stdin>:8: Warning: NER end tag does not match start tag EnamexProXxx-B: "EnamexLocStr-E"
+      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: EnamexLocStr-B
+      vrt-augment-name-attrs: <stdin>:8: Warning: NER end tag does not match start tag EnamexProXxx-B: EnamexLocStr-E
 
 - name: 'vrt-augment-name-attrs: Invalid NER begin and end tags within a multi-level name'
   input:
@@ -277,9 +277,9 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:7: Warning: Nested NER tag EnamexOrgClt-B-1 already open at level 1: "EnamexLocStr-B-1"
-      vrt-augment-name-attrs: <stdin>:8: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
-      vrt-augment-name-attrs: <stdin>:16: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
+      vrt-augment-name-attrs: <stdin>:7: Warning: Nested NER tag EnamexOrgClt-B-1 already open at level 1: EnamexLocStr-B-1
+      vrt-augment-name-attrs: <stdin>:8: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: EnamexLocStr-E-1
+      vrt-augment-name-attrs: <stdin>:16: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: EnamexLocStr-E-1
 
 - name: 'vrt-augment-name-attrs: Name does not end within a sentence'
   input:
@@ -301,9 +301,9 @@
   output:
     stdout: *input-sentence-breaks-name
     stderr: |
-      vrt-augment-name-attrs: <stdin>:4: Warning: NER start tag without end tag within sentence: "EnamexLocStr-B"
-      vrt-augment-name-attrs: <stdin>:7: Warning: NER end tag without start tag: "EnamexLocStr-E"
-      vrt-augment-name-attrs: <stdin>:10: Warning: NER start tag without end tag within sentence: "EnamexLocStr-B"
+      vrt-augment-name-attrs: <stdin>:4: Warning: NER start tag without end tag within sentence: EnamexLocStr-B
+      vrt-augment-name-attrs: <stdin>:7: Warning: NER end tag without start tag: EnamexLocStr-E
+      vrt-augment-name-attrs: <stdin>:10: Warning: NER start tag without end tag within sentence: EnamexLocStr-B
 
 - name: 'vrt-augment-name-attrs: End of input at the middle of name'
   input:
@@ -345,7 +345,7 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:4: Warning: No end tag for nested NER tag: "EnamexLocPpl-B-1"
+      vrt-augment-name-attrs: <stdin>:4: Warning: No end tag for nested NER tag: EnamexLocPpl-B-1
 
 
 # No names

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -46,22 +46,6 @@
     stderr: |
       vrt-augment-name-attrs: No positional attribute 'nertag2' in input
 
-- name: 'vrt-augment-name-attrs: No lemma attribute'
-  input:
-    cmdline: vrt-augment-name-attrs
-    stdin: |
-      <!-- #vrt positional-attributes: word nertag2 -->
-      <text a="b">
-      <sentence x="y">
-      a	_
-      </sentence>
-      </text>
-  output:
-    returncode: 1
-    stdout: ''
-    stderr: |
-      vrt-augment-name-attrs: No positional attribute 'lemma' in input
-
 - name: 'vrt-augment-name-attrs: No word attribute'
   input:
     cmdline: vrt-augment-name-attrs
@@ -704,6 +688,78 @@
       <ne name="15&quot;&quot; tuuman" fulltype="NumexMsrXxx" ex="NUMEX" type="MSR" subtype="XXX" placename="" placename_source="">
       15""	15""	NumexMsrXxx-B	|NumexMsrXxx-B-0|	B-MISC
       tuuman	tuuma	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Inflected names, no lemmas'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Ahteesta	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      Aaltosen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Ahteesta" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahteesta	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      </ne>
+      <ne name="Ahti Karjalaisen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="Aaltosen taidemuseossa" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      <ne name="Aaltosen" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Aaltosen" placename_source="ner">
+      Aaltosen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      </ne>
+      taidemuseossa	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: Warning: No positional attribute 'lemma' in input; using word forms in the place of lemmas
+
+- name: 'vrt-augment-name-attrs: Inflected names, explicitly ignore lemmas'
+  input:
+    cmdline: vrt-augment-name-attrs --lemma=""
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Ahteesta	ahde	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      Ahti	Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	Karjalainen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Ahteesta" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahteesta	ahde	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+      </ne>
+      <ne name="Ahti Karjalaisen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+      Ahti	Ahti	EnamexPrsHum-B	|EnamexPrsHum-B-0|	B-PER
+      Karjalaisen	Karjalainen	EnamexPrsHum-E	|EnamexPrsHum-E-0|	I-PER
+      </ne>
+      <ne name="Aaltosen taidemuseossa" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      <ne name="Aaltosen" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Aaltosen" placename_source="ner">
+      Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      </ne>
+      taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
       </ne>
       </sentence>
       </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -78,6 +78,84 @@
     stderr: |
       vrt-augment-name-attrs: No positional attribute 'word' in input
 
+- name: 'vrt-augment-name-attrs: Invalid NER tags'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: &input-invalid-nertag |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      A	a		|	O
+      on	olla	A	|	O
+      alussa	alku	1	|	O
+      .	.	A-1	|	O
+      </sentence>
+      </text>
+  output:
+    stdout: *input-invalid-nertag
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid NER tag: ""
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag: "A"
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag: "1"
+      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag: "A-1"
+
+- name: 'vrt-augment-name-attrs: Invalid NER tags within a name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Äänikortti	äänikortti	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Sound	Sound	EnamexProXxx-B	|	I-PRO
+      Blaster	Blaster	EnamexProXxx-F	|	I-PRO
+      Live	live		|	I-PRO
+      Plus	plus	1	|	I-PRO
+      1024	1024	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="Äänikortti Sound Blaster Live Plus 1024" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      Äänikortti	äänikortti	EnamexProXxx-B	|EnamexProXxx-B-0|	B-PRO
+      Sound	Sound	EnamexProXxx-B	|	I-PRO
+      Blaster	Blaster	EnamexProXxx-F	|	I-PRO
+      Live	live		|	I-PRO
+      Plus	plus	1	|	I-PRO
+      1024	1024	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag within name: "EnamexProXxx-B"
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag within name: "EnamexProXxx-F"
+      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: ""
+      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag within name: "1"
+
+- name: 'vrt-augment-name-attrs: NER end tag without start tag'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Aalto	aalto	EnamexPrsHum-E	|EnamexPrsHum-E-0|	B-PRS
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Aalto	aalto	EnamexPrsHum-E	|EnamexPrsHum-E-0|	B-PRS
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:4: Warning: NER end tag without start tag: "EnamexPrsHum-E"
+
 
 # No names
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -89,6 +89,15 @@
       on	olla	A	|	O
       alussa	alku	1	|	O
       .	.	A-1	|	O
+      X	x	NamexFooBar-F	|	O
+      X	x	EnamexFoo-F	|	O
+      X	x	EnamexFB-F	|	O
+      X	x	ENAMEXPRSHUM-F	|	O
+      X	x	EnamexFo1Bo1-F	|	O
+      X	x	EnamexFooBarBaz-F	|	O
+      X	x	EnamexFooB-F	|	O
+      X	x	EnamexFBar-F	|	O
+      X	x	EnamexFoBo-G	|	O
       </sentence>
       </text>
   output:
@@ -97,6 +106,15 @@
       vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag: "A"
       vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag: "1"
       vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag: "A-1"
+      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: "NamexFooBar-F"
+      vrt-augment-name-attrs: <stdin>:9: Warning: Invalid NER tag: "EnamexFoo-F"
+      vrt-augment-name-attrs: <stdin>:10: Warning: Invalid NER tag: "EnamexFB-F"
+      vrt-augment-name-attrs: <stdin>:11: Warning: Invalid NER tag: "ENAMEXPRSHUM-F"
+      vrt-augment-name-attrs: <stdin>:12: Warning: Invalid NER tag: "EnamexFo1Bo1-F"
+      vrt-augment-name-attrs: <stdin>:13: Warning: Invalid NER tag: "EnamexFooBarBaz-F"
+      vrt-augment-name-attrs: <stdin>:14: Warning: Invalid NER tag: "EnamexFooB-F"
+      vrt-augment-name-attrs: <stdin>:15: Warning: Invalid NER tag: "EnamexFBar-F"
+      vrt-augment-name-attrs: <stdin>:16: Warning: Invalid NER tag: "EnamexFoBo-G"
 
 - name: 'vrt-augment-name-attrs: Invalid NER tags within a name'
   input:
@@ -131,7 +149,7 @@
     stderr: |
       vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag within name: "EnamexProXxx-B"
       vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag within name: "EnamexProXxx-F"
-      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag within name: "1"
+      vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag: "1"
 
 - name: 'vrt-augment-name-attrs: Invalid NER tags in multi-level NER attribute'
   input:
@@ -351,6 +369,66 @@
       5	.	O	_	|	z	.
       </sentence>
       </text>
+
+- name: 'vrt-augment-name-attrs: Single-word names, arbitrary name types'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      01.06.2001	01.06.2001	TimexTmDa-F	|TimexTmDa-F-0|	B-DATE
+      1.07	1.07	TimexTimeHourminsecs-F	|TimexTimeHourminsecs-F-0|	B-MISC
+      A100	A100	EnamexPrXx-F	|EnamexPrXx-F-0|	B-PRO
+      Aaltoseen	Aaltonen	EnamexPersonHuman-F	|EnamexPersonHuman-F-0|	B-PER
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      <ne name="01.06.2001" fulltype="TimexTmDa" ex="TIMEX" type="TM" subtype="DA" placename="" placename_source="">
+      01.06.2001	01.06.2001	TimexTmDa-F	|TimexTmDa-F-0|	B-DATE
+      </ne>
+      <ne name="1.07" fulltype="TimexTimeHourminsecs" ex="TIMEX" type="TIME" subtype="HOURMINSECS" placename="" placename_source="">
+      1.07	1.07	TimexTimeHourminsecs-F	|TimexTimeHourminsecs-F-0|	B-MISC
+      </ne>
+      <ne name="A100" fulltype="EnamexPrXx" ex="ENAMEX" type="PR" subtype="XX" placename="" placename_source="">
+      A100	A100	EnamexPrXx-F	|EnamexPrXx-F-0|	B-PRO
+      </ne>
+      <ne name="Aaltonen" fulltype="EnamexPersonHuman" ex="ENAMEX" type="PERSON" subtype="HUMAN" placename="" placename_source="">
+      Aaltoseen	Aaltonen	EnamexPersonHuman-F	|EnamexPersonHuman-F-0|	B-PER
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-level names, arbitrary nested name types'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLoPp-B-1|EnamexLocationPolitical-F-2|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLoPp-E-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Lapuan hiippakunta" fulltype="EnamexLoPp" ex="ENAMEX" type="LO" subtype="PP" placename="" placename_source="">
+      <ne name="Lapua" fulltype="EnamexLocationPolitical" ex="ENAMEX" type="LOCATION" subtype="POLITICAL" placename="" placename_source="">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLoPp-B-1|EnamexLocationPolitical-F-2|	B-ORG
+      </ne>
+      hiippakunnan	hiippakunta	_	|EnamexLoPp-E-1|	I-ORG
+      </ne>
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
 
 
 # Multi-word names

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -135,6 +135,36 @@
       vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: ""
       vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag within name: "1"
 
+- name: 'vrt-augment-name-attrs: Invalid NER tags in multi-level NER attribute'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-X|F-X-12|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-1|F-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-X|F-X-12|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-1|F-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "EnamexLocPpl-B-X"
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "F-X-12"
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "EnamexLocPpl-1"
+      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "F-1"
+
 - name: 'vrt-augment-name-attrs: NER end tag without start tag'
   input:
     cmdline: vrt-augment-name-attrs
@@ -219,6 +249,38 @@
         </sentence>
         </text>
       transform: *transf-attr-names
+
+- name: 'vrt-augment-name-attrs: --multi-nertag'
+  input:
+    cmdline:
+    - vrt-augment-name-attrs --multi-nertag=nertags
+    # The same with slash at the end of the attribute name
+    - vrt-augment-name-attrs --multi-nertag=nertags/
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Lapuan hiippakunta" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Lapuan hiippakunta" placename_source="ner">
+      <ne name="Lapua" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Lapua" placename_source="ner">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      </ne>
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
+      </ne>
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>
 
 
 # Single-word names
@@ -410,7 +472,9 @@
       Avenue	avenue	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
       </ne>
       <ne name="Aaltosen taidemuseo" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      <ne name="Aaltonen" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Aaltonen" placename_source="ner">
       Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      </ne>
       taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
       </ne>
       <ne name="AAMOS" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
@@ -469,7 +533,9 @@
       kg	kg	NumexMsrXxx-E	|NumexMsrXxx-E-0|	I-MISC
       </ne>
       <ne name="Saab 9000 170hp-&gt;235hp" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      <ne name="Saab" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       Saab	Saab	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      </ne>
       9000	9000	_	|	I-PRO
       170hp-&gt;235hp	170hp-&gt;235hp	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
       </ne>
@@ -767,57 +833,240 @@
       <ne name="100 miljardia Suomen markkaa" fulltype="NumexMsrCur" ex="NUMEX" type="MSR" subtype="CUR" placename="" placename_source="">
       100	100	NumexMsrCur-B	|NumexMsrCur-B-0|	B-MISC
       miljardia	miljardi	_	|	I-MISC
+      <ne name="Suomi" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Suomi" placename_source="ner">
       Suomen	Suomi	_	|EnamexLocPpl-F-1|	I-MISC
+      </ne>
       markkaa	markka	NumexMsrCur-E	|NumexMsrCur-E-0|	I-MISC
       </ne>
       <ne name="9.40 Keski-Euroopan aikaa" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
       9.40	9.40	TimexTmeHrm-B	|TimexTmeHrm-B-0|	B-MISC
+      <ne name="Keski-Euroopan" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Keski-Euroopan" placename_source="ner">
       Keski-Euroopan	Keski-Euroopan	_	|EnamexLocPpl-F-1|	I-MISC
+      </ne>
       aikaa	aika	TimexTmeHrm-E	|TimexTmeHrm-E-0|	I-MISC
       </ne>
       <ne name="Aaltosen taidemuseo" fulltype="EnamexOrgClt" ex="ENAMEX" type="ORG" subtype="CLT" placename="" placename_source="">
+      <ne name="Aaltonen" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Aaltonen" placename_source="ner">
       Aaltosen	Aaltonen	EnamexOrgClt-B	|EnamexOrgClt-B-0|EnamexLocPpl-F-1|	B-ORG
+      </ne>
       taidemuseossa	taidemuseo	EnamexOrgClt-E	|EnamexOrgClt-E-0|	I-ORG
       </ne>
       <ne name="Adobe Acrobat" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      <ne name="Adobe" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       Adobe	Adobe	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-F-1|	B-PRO
+      </ne>
       Acrobat	Acrobat	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
       </ne>
       <ne name="Agia Napan vesipuisto" fulltype="EnamexLocFnc" ex="ENAMEX" type="LOC" subtype="FNC" placename="Agia Napan vesipuisto" placename_source="ner">
+      <ne name="Agia Nappa" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Agia Nappa" placename_source="ner">
       Agia	Agia	EnamexLocFnc-B	|EnamexLocFnc-B-0|EnamexLocPpl-B-1|	B-LOC
       Napan	nappa	_	|EnamexLocPpl-E-1|	I-LOC
+      </ne>
       vesipuistossa	vesipuisto	EnamexLocFnc-E	|EnamexLocFnc-E-0|	I-LOC
       </ne>
       <ne name="Alfa Romeo 155 2.0 16V" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+      <ne name="Alfa Romeo" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       Alfa	alfa	EnamexProXxx-B	|EnamexProXxx-B-0|EnamexOrgCrp-B-1|	B-PRO
       Romeo	Romeo	_	|EnamexOrgCrp-E-1|	I-PRO
+      </ne>
       155	155	_	|	I-PRO
       2.0 16V	2.0 16V	EnamexProXxx-E	|EnamexProXxx-E-0|	I-PRO
       </ne>
       </sentence>
       </text>
 
-- name: 'vrt-augment-name-attrs: Three-level names'
+- name: 'vrt-augment-name-attrs: Multi-level names'
   input:
     cmdline: vrt-augment-name-attrs
-    stdin: |
+    stdin: &input-multilevel |
       <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
       <text a="b">
-      <sentence x="y">
+      <sentence x="1">
       Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
       hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
       tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      <!-- The following examples are artificial for testing purposes; -->
+      <!-- FiNER most likely would not tag them this way. -->
+      <sentence x="2">
+      Turun	Turku	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexOrgCrp-B-2|EnamexLocPpl-B-3|EnamexLocPpl-F-4|	B-PRS
+      ja	ja	_	|		I-PRS
+      Porin	Pori	_	|EnamexLocPpl-F-4|	I-PRS
+      läänin	lääni	_	|EnamexLocPpl-E-3|	I-PRS
+      lääninhallituksen	lääninhallitus	_	|EnamexOrgCrp-E-2|	I-PRS
+      talousvaliokunnan	talousvaliokunta	_	|EnamexOrgCrp-E-1|	I-PRS
+      puheenjohtajalla	puheenjohtaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
+      </sentence>
+      <sentence x="3">
+      Trinidadin	Trinidad	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexLocPpl-B-2|EnamexLocPpl-F-3|	B-PRS
+      ja	ja	_	|	I-PRS
+      Tobagon	Tobago	_	|EnamexLocPpl-E-2|EnamexLocPpl-F-3|	I-PRS
+      sekä	sekä	_	|	I-PRS
+      Saint	Saint	_	|EnamexLocPpl-B-2|EnamexLocPpl-B-3|	I-PRS
+      Christopherin	Christopher	_	|EnamexLocPpl-E-3|	I-PRS
+      ja	ja	_	|	I-PRS
+      Nevisin	Nevis	_	|EnamexLocPpl-F-3|	I-PRS
+      federaation	federaatio	_	|EnamexLocPpl-E-2|	I-PRS
+      liiton	liitto	_	|EnamexOrgCrp-E-1|	I-PRS
+      Ison-Britannian	Iso-Britannia	_	|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	I-PRS
+      ja	ja	_	|	I-PRS
+      Pohjois-Irlannin	Pohjois-Irlanti	_	|EnamexLocPpl-F-2|	I-PRS
+      yhdistyneen	yhdistynyt	_	|	I-PRS
+      kuningaskunnan	kuningaskunta	_	|EnamexLocPpl-E-1|	I-PRS
+      asiainhoitajalla	asiainhoitaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
       </sentence>
       </text>
   output:
     stdout: |
       <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
       <text a="b">
-      <sentence x="y">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Lapuan hiippakunta" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Lapuan hiippakunta" placename_source="ner">
+      <ne name="Lapua" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Lapua" placename_source="ner">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      </ne>
+      hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
+      </ne>
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      <!-- The following examples are artificial for testing purposes; -->
+      <!-- FiNER most likely would not tag them this way. -->
+      <sentence x="2">
+      <ne name="Turun ja Porin läänin lääninhallituksen talousvaliokunnan puheenjohtaja" fulltype="EnamexPrsTit" ex="ENAMEX" type="PRS" subtype="TIT" placename="" placename_source="">
+      <ne name="Turun ja Porin läänin lääninhallituksen talousvaliokunta" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Turun ja Porin läänin lääninhallitus" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Turun ja Porin lääni" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Turun ja Porin lääni" placename_source="ner">
+      <ne name="Turku" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Turku" placename_source="ner">
+      Turun	Turku	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexOrgCrp-B-2|EnamexLocPpl-B-3|EnamexLocPpl-F-4|	B-PRS
+      </ne>
+      ja	ja	_	|		I-PRS
+      <ne name="Pori" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Pori" placename_source="ner">
+      Porin	Pori	_	|EnamexLocPpl-F-4|	I-PRS
+      </ne>
+      läänin	lääni	_	|EnamexLocPpl-E-3|	I-PRS
+      </ne>
+      lääninhallituksen	lääninhallitus	_	|EnamexOrgCrp-E-2|	I-PRS
+      </ne>
+      talousvaliokunnan	talousvaliokunta	_	|EnamexOrgCrp-E-1|	I-PRS
+      </ne>
+      puheenjohtajalla	puheenjohtaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
+      </ne>
+      </sentence>
+      <sentence x="3">
+      <ne name="Trinidadin ja Tobagon sekä Saint Christopherin ja Nevisin federaation liiton Ison-Britannian ja Pohjois-Irlannin yhdistyneen kuningaskunnan asiainhoitaja" fulltype="EnamexPrsTit" ex="ENAMEX" type="PRS" subtype="TIT" placename="" placename_source="">
+      <ne name="Trinidadin ja Tobagon sekä Saint Christopherin ja Nevisin federaation liitto" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Trinidadin ja Tobago" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Trinidadin ja Tobago" placename_source="ner">
+      <ne name="Trinidad" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Trinidad" placename_source="ner">
+      Trinidadin	Trinidad	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexLocPpl-B-2|EnamexLocPpl-F-3|	B-PRS
+      </ne>
+      ja	ja	_	|	I-PRS
+      <ne name="Tobago" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Tobago" placename_source="ner">
+      Tobagon	Tobago	_	|EnamexLocPpl-E-2|EnamexLocPpl-F-3|	I-PRS
+      </ne>
+      </ne>
+      sekä	sekä	_	|	I-PRS
+      <ne name="Saint Christopherin ja Nevisin federaatio" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Saint Christopherin ja Nevisin federaatio" placename_source="ner">
+      <ne name="Saint Christopher" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Saint Christopher" placename_source="ner">
+      Saint	Saint	_	|EnamexLocPpl-B-2|EnamexLocPpl-B-3|	I-PRS
+      Christopherin	Christopher	_	|EnamexLocPpl-E-3|	I-PRS
+      </ne>
+      ja	ja	_	|	I-PRS
+      <ne name="Nevis" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Nevis" placename_source="ner">
+      Nevisin	Nevis	_	|EnamexLocPpl-F-3|	I-PRS
+      </ne>
+      federaation	federaatio	_	|EnamexLocPpl-E-2|	I-PRS
+      </ne>
+      liiton	liitto	_	|EnamexOrgCrp-E-1|	I-PRS
+      </ne>
+      <ne name="Ison-Britannian ja Pohjois-Irlannin yhdistyneen kuningaskunta" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Ison-Britannian ja Pohjois-Irlannin yhdistyneen kuningaskunta" placename_source="ner">
+      <ne name="Iso-Britannia" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Iso-Britannia" placename_source="ner">
+      Ison-Britannian	Iso-Britannia	_	|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	I-PRS
+      </ne>
+      ja	ja	_	|	I-PRS
+      <ne name="Pohjois-Irlanti" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Pohjois-Irlanti" placename_source="ner">
+      Pohjois-Irlannin	Pohjois-Irlanti	_	|EnamexLocPpl-F-2|	I-PRS
+      </ne>
+      yhdistyneen	yhdistynyt	_	|	I-PRS
+      kuningaskunnan	kuningaskunta	_	|EnamexLocPpl-E-1|	I-PRS
+      </ne>
+      asiainhoitajalla	asiainhoitaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: Multi-level names, --maximal-only'
+  input:
+    cmdline: vrt-augment-name-attrs --maximal-only
+    stdin: *input-multilevel
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
       <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
       hiippakunnan	hiippakunta	_	|EnamexLocPpl-E-1|	I-ORG
       tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      <!-- The following examples are artificial for testing purposes; -->
+      <!-- FiNER most likely would not tag them this way. -->
+      <sentence x="2">
+      <ne name="Turun ja Porin läänin lääninhallituksen talousvaliokunnan puheenjohtaja" fulltype="EnamexPrsTit" ex="ENAMEX" type="PRS" subtype="TIT" placename="" placename_source="">
+      Turun	Turku	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexOrgCrp-B-2|EnamexLocPpl-B-3|EnamexLocPpl-F-4|	B-PRS
+      ja	ja	_	|		I-PRS
+      Porin	Pori	_	|EnamexLocPpl-F-4|	I-PRS
+      läänin	lääni	_	|EnamexLocPpl-E-3|	I-PRS
+      lääninhallituksen	lääninhallitus	_	|EnamexOrgCrp-E-2|	I-PRS
+      talousvaliokunnan	talousvaliokunta	_	|EnamexOrgCrp-E-1|	I-PRS
+      puheenjohtajalla	puheenjohtaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
+      </ne>
+      </sentence>
+      <sentence x="3">
+      <ne name="Trinidadin ja Tobagon sekä Saint Christopherin ja Nevisin federaation liiton Ison-Britannian ja Pohjois-Irlannin yhdistyneen kuningaskunnan asiainhoitaja" fulltype="EnamexPrsTit" ex="ENAMEX" type="PRS" subtype="TIT" placename="" placename_source="">
+      Trinidadin	Trinidad	EnamexPrsTit-B	|EnamexPrsTit-B-0|EnamexOrgCrp-B-1|EnamexLocPpl-B-2|EnamexLocPpl-F-3|	B-PRS
+      ja	ja	_	|	I-PRS
+      Tobagon	Tobago	_	|EnamexLocPpl-E-2|EnamexLocPpl-F-3|	I-PRS
+      sekä	sekä	_	|	I-PRS
+      Saint	Saint	_	|EnamexLocPpl-B-2|EnamexLocPpl-B-3|	I-PRS
+      Christopherin	Christopher	_	|EnamexLocPpl-E-3|	I-PRS
+      ja	ja	_	|	I-PRS
+      Nevisin	Nevis	_	|EnamexLocPpl-F-3|	I-PRS
+      federaation	federaatio	_	|EnamexLocPpl-E-2|	I-PRS
+      liiton	liitto	_	|EnamexOrgCrp-E-1|	I-PRS
+      Ison-Britannian	Iso-Britannia	_	|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	I-PRS
+      ja	ja	_	|	I-PRS
+      Pohjois-Irlannin	Pohjois-Irlanti	_	|EnamexLocPpl-F-2|	I-PRS
+      yhdistyneen	yhdistynyt	_	|	I-PRS
+      kuningaskunnan	kuningaskunta	_	|EnamexLocPpl-E-1|	I-PRS
+      asiainhoitajalla	asiainhoitaja	EnamexPrsTit-E	|EnamexPrsTit-E-0|	I-PRS
+      </ne>
+      </sentence>
+      </text>
+
+- name: 'vrt-augment-name-attrs: --maximal-only, no multi-level NER attribute'
+  input:
+    cmdline: vrt-augment-name-attrs --maximal-only
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Lapuan	Lapua	EnamexOrgCrp-B	B-ORG
+      hiippakunnan	hiippakunta	_	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      Lapuan	Lapua	EnamexOrgCrp-B	B-ORG
+      hiippakunnan	hiippakunta	_	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	I-ORG
       </ne>
       </sentence>
       </text>

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -234,6 +234,35 @@
     stderr: |
       vrt-augment-name-attrs: <stdin>:3: Warning: End of input at the middle of a name: EnamexLocStr-E expected
 
+- name: 'vrt-augment-name-attrs: Nested NER tag not closed at end of maximal name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      hiippakunnan	hiippakunta	_	|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </sentence>
+      </text>
+  output:
+    stdout: |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="1">
+      <ne name="Lapuan hiippakunnan tuomiokapituli" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
+      <ne name="Lapua" fulltype="EnamexLocPpl" ex="ENAMEX" type="LOC" subtype="PPL" placename="Lapua" placename_source="ner">
+      Lapuan	Lapua	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|EnamexLocPpl-B-1|EnamexLocPpl-F-2|	B-ORG
+      </ne>
+      hiippakunnan	hiippakunta	_	|	I-ORG
+      tuomiokapituli	tuomiokapituli	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
+      </ne>
+      </sentence>
+      </text>
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:6: Warning: No end tag for nested NER tag: "EnamexLocPpl-B-1"
+
 
 # No names
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -160,10 +160,10 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "EnamexLocPpl-B-X"
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "F-X-12"
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "EnamexLocPpl-1"
-      vrt-augment-name-attrs: <stdin>:6: Warning: Invalid nested NER tag: "F-1"
+      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: "EnamexLocPpl-B-X"
+      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid nested NER tag: "F-X-12"
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: "EnamexLocPpl-1"
+      vrt-augment-name-attrs: <stdin>:5: Warning: Invalid nested NER tag: "F-1"
 
 - name: 'vrt-augment-name-attrs: NER end tag without start tag'
   input:
@@ -277,9 +277,9 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:10: Warning: Nested NER tag EnamexOrgClt-B-1 already open at level 1: "EnamexLocStr-B-1"
-      vrt-augment-name-attrs: <stdin>:10: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
-      vrt-augment-name-attrs: <stdin>:18: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
+      vrt-augment-name-attrs: <stdin>:7: Warning: Nested NER tag EnamexOrgClt-B-1 already open at level 1: "EnamexLocStr-B-1"
+      vrt-augment-name-attrs: <stdin>:8: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
+      vrt-augment-name-attrs: <stdin>:16: Warning: Nested NER end tag does not match start tag EnamexOrgClt-B-1: "EnamexLocStr-E-1"
 
 - name: 'vrt-augment-name-attrs: Name does not end within a sentence'
   input:
@@ -345,7 +345,7 @@
       </sentence>
       </text>
     stderr: |
-      vrt-augment-name-attrs: <stdin>:6: Warning: No end tag for nested NER tag: "EnamexLocPpl-B-1"
+      vrt-augment-name-attrs: <stdin>:4: Warning: No end tag for nested NER tag: "EnamexLocPpl-B-1"
 
 
 # No names

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -98,40 +98,59 @@
     stdout: *input-no-names
 
 
+# Attribute-name options
+
+- name: 'vrt-augment-name-attrs: Attribute-name options'
+  input:
+    cmdline: vrt-augment-name-attrs --word=wd --lemma=bf --nertag=nertag
+    stdin:
+      value: &input-single1 |
+        <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+        <text a="b">
+        <sentence x="y">
+        01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+        1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+        A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+        Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+        </sentence>
+        </text>
+      transform: &transf-attr-names
+        python: |
+          lines = value.split('\n')
+          lines[0] = (lines[0].replace('word', 'wd').replace('lemma', 'bf')
+                      .replace('nertag2', 'nertag'))
+          return '\n'.join(lines)
+  output:
+    stdout:
+      value: &output-single1 |
+        <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+        <text a="b">
+        <sentence x="y">
+        <ne name="01.06.2001" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
+        01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
+        </ne>
+        <ne name="1.07" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
+        1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
+        </ne>
+        <ne name="A100" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
+        A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
+        </ne>
+        <ne name="Aaltonen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
+        Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
+        </ne>
+        </sentence>
+        </text>
+      transform: *transf-attr-names
+
+
 # Single-word names
 
 - name: 'vrt-augment-name-attrs: Single-word names, nothing else'
   input:
     cmdline: vrt-augment-name-attrs
-    stdin: |
-      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
-      <text a="b">
-      <sentence x="y">
-      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
-      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
-      A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
-      Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
-      </sentence>
-      </text>
+    stdin: *input-single1
   output:
-    stdout: |
-      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
-      <text a="b">
-      <sentence x="y">
-      <ne name="01.06.2001" fulltype="TimexTmeDat" ex="TIMEX" type="TME" subtype="DAT" placename="" placename_source="">
-      01.06.2001	01.06.2001	TimexTmeDat-F	|TimexTmeDat-F-0|	B-DATE
-      </ne>
-      <ne name="1.07" fulltype="TimexTmeHrm" ex="TIMEX" type="TME" subtype="HRM" placename="" placename_source="">
-      1.07	1.07	TimexTmeHrm-F	|TimexTmeHrm-F-0|	B-MISC
-      </ne>
-      <ne name="A100" fulltype="EnamexProXxx" ex="ENAMEX" type="PRO" subtype="XXX" placename="" placename_source="">
-      A100	A100	EnamexProXxx-F	|EnamexProXxx-F-0|	B-PRO
-      </ne>
-      <ne name="Aaltonen" fulltype="EnamexPrsHum" ex="ENAMEX" type="PRS" subtype="HUM" placename="" placename_source="">
-      Aaltoseen	Aaltonen	EnamexPrsHum-F	|EnamexPrsHum-F-0|	B-PER
-      </ne>
-      </sentence>
-      </text>
+    stdout: *output-single1
 
 - name: 'vrt-augment-name-attrs: Single-word names, non-name tokens'
   input:

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -94,7 +94,6 @@
   output:
     stdout: *input-invalid-nertag
     stderr: |
-      vrt-augment-name-attrs: <stdin>:4: Warning: Invalid NER tag: ""
       vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag: "A"
       vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag: "1"
       vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag: "A-1"
@@ -132,7 +131,6 @@
     stderr: |
       vrt-augment-name-attrs: <stdin>:5: Warning: Invalid NER tag within name: "EnamexProXxx-B"
       vrt-augment-name-attrs: <stdin>:6: Warning: Invalid NER tag within name: "EnamexProXxx-F"
-      vrt-augment-name-attrs: <stdin>:7: Warning: Invalid NER tag within name: ""
       vrt-augment-name-attrs: <stdin>:8: Warning: Invalid NER tag within name: "1"
 
 - name: 'vrt-augment-name-attrs: Invalid NER tags in multi-level NER attribute'

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -202,6 +202,38 @@
     stderr: |
       vrt-augment-name-attrs: <stdin>:4: Warning: NER end tag without start tag: "EnamexPrsHum-E"
 
+- name: 'vrt-augment-name-attrs: Name does not end within a sentence'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: &input-sentence-breaks-name |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Aamuruskontie	aamuruskotie	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      </sentence>
+      <sentence x="z">
+      6	6	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
+      </sentence>
+      </text>
+  output:
+    stdout: *input-sentence-breaks-name
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:5: Warning: No NER end tag for EnamexLocStr-B within sentence
+      vrt-augment-name-attrs: <stdin>:7: Warning: NER end tag without start tag: "EnamexLocStr-E"
+
+- name: 'vrt-augment-name-attrs: End of input at the middle of name'
+  input:
+    cmdline: vrt-augment-name-attrs
+    stdin: &input-unexpected-end |
+      <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
+      <text a="b">
+      <sentence x="y">
+      Aamuruskontie	aamuruskotie	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+  output:
+    stdout: *input-unexpected-end
+    stderr: |
+      vrt-augment-name-attrs: <stdin>:3: Warning: End of input at the middle of a name: EnamexLocStr-E expected
+
 
 # No names
 

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -412,7 +412,6 @@
 # Intra-sentence tags
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence comments'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |
@@ -477,7 +476,6 @@
       </text>
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure covers first word of name'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |
@@ -497,8 +495,8 @@
       <!-- #vrt positional-attributes: word lemma nertag2 nertags2/ nerbio2 -->
       <text a="b">
       <sentence x="y">
-      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       <emph>
+      <ne name="Saaristo Siistinä ry:llä" fulltype="EnamexOrgCrp" ex="ENAMEX" type="ORG" subtype="CRP" placename="" placename_source="">
       Saaristo	saaristo	EnamexOrgCrp-B	|EnamexOrgCrp-B-0|	B-ORG
       </emph>
       Siistinä	siisti	_	|	I-ORG
@@ -509,7 +507,6 @@
       </text>
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure ends within name'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |
@@ -543,7 +540,6 @@
       </text>
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure covers last word of name'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |
@@ -568,14 +564,13 @@
       Siistinä	siisti	_	|	I-ORG
       <emph>
       ry:llä	ry:llä	EnamexOrgCrp-E	|EnamexOrgCrp-E-0|	I-ORG
-      </emph>
       </ne>
+      </emph>
       .	.	_	|	O
       </sentence>
       </text>
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure begins within name'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |
@@ -607,7 +602,6 @@
       </text>
 
 - name: 'vrt-augment-name-attrs: Multi-word names, intra-sentence structure completely within name'
-  status: xfail:Intra-name tags not yet handled correctly
   input:
     cmdline: vrt-augment-name-attrs
     stdin: |

--- a/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
+++ b/vrt-tools/tests/scripttests/scripttest_vrt_augment_name_attrs.yaml
@@ -198,12 +198,17 @@
       <sentence x="z">
       6	6	EnamexLocStr-E	|EnamexLocStr-E-0|	I-LOC
       </sentence>
+      <sentence x="y">
+      Aamuruskontie	aamuruskotie	EnamexLocStr-B	|EnamexLocStr-B-0|	B-LOC
+      6	6	_	|	I-LOC
+      </sentence>
       </text>
   output:
     stdout: *input-sentence-breaks-name
     stderr: |
       vrt-augment-name-attrs: <stdin>:5: Warning: No NER end tag for EnamexLocStr-B within sentence
       vrt-augment-name-attrs: <stdin>:7: Warning: NER end tag without start tag: "EnamexLocStr-E"
+      vrt-augment-name-attrs: <stdin>:12: Warning: No NER end tag for EnamexLocStr-B within sentence
 
 - name: 'vrt-augment-name-attrs: End of input at the middle of name'
   input:

--- a/vrt-tools/vrt-augment-name-attrs
+++ b/vrt-tools/vrt-augment-name-attrs
@@ -1,0 +1,17 @@
+#! /usr/bin/env python3
+# -*- mode: Python; -*-
+
+"""
+vrt-augment-name-attrs
+
+A VRT tool to augment name attributes with ne structures.
+
+The actual implementation is in libvrt.tools.vrt_augment_name_attrs.
+"""
+
+
+from libvrt.tools.vrt_augment_name_attrs import VrtNameAttrAugmenter
+
+
+if __name__ == '__main__':
+    VrtNameAttrAugmenter().run()


### PR DESCRIPTION
Add `vrt-augment-name-attrs`, a VRT tool to add `ne` structures (elements) and their attributes (annotations) based on positional NER attributes (`nertag2`, `nertags2`, `nerbio2`) as produced by `vrt-finnish-nertag`.

Usage:
```
usage: vrt-augment-name-attrs [-h]
                              [--out file | --in-place | --backup bak | --in-sibling EXT]
                              [--version] [--word attr] [--lemma attr] [--nertag attr]
                              [--multi-nertag attr] [--maximal-only]
                              [file]

Augment VRT input containing positional name attributes with <ne> structures with
attributes. The tool expects a positional attribute to contain NER tags for maximal names,
matching the regular expression "(Ena|Nu|Ti)mex[A-Z][a-z]+[A-Z][a-z]+-[BEF]", as produced by
vrt-finnish-nertag. Another attribute can contain a set of NER tags for possible nested
names, with "-N" appended where N is the nesting level.

positional arguments:
  file                  input file (default stdin)

options:
  [… Standard VRT tool options …]
  --word attr           positional attribute name for word form is attr (default: "word")
  --lemma attr          positional attribute name for base form (lemma) is attr; if the
                        input does not contain attr, use word forms in the place of lemmas
                        (specify "" to suppress a warning) (default: "lemma")
  --nertag attr         positional attribute name for maximal NER tag is attr (default:
                        "nertag2")
  --multi-nertag attr   positional attribute name for multiple (nested, non-maximal) NER
                        tags is attr (default: "nertags2")
  --maximal-only        enclose only maximal names, no nested ones
```

Tests are included for the tool.