### PR TITLE
Import Korp corpus configuration conversion script from Korp backend

### DIFF
--- a/korp-tools/korp-corpus-configs-json2yaml
+++ b/korp-tools/korp-corpus-configs-json2yaml
@@ -1,11 +1,11 @@
 #! /usr/bin/env python3
 
-# corpus-configs-json2yaml
+# korp-corpus-configs-json2yaml
 #
 # Convert Korp corpus configurations from frontend JavaScript
 # (stringified to JSON) to backend YAML.
 #
-# Usage: corpus-configs-json2yaml [--outdir outputdir] input.json
+# Usage: korp-corpus-configs-json2yaml [--outdir outputdir] input.json
 #
 # input.json is a JSON file containing the representation of a
 # JavaScript object combining the following objects in the Korp


### PR DESCRIPTION
Import (or move) the Korp configuration conversion script from the [branch `utils/convert-corpus-configs` of Kielipankki-korp-backend](../../Kielipankki-korp-backend/tree/utils/convert-corpus-configs) by merging that branch here with full commit history. (As the branch is independent, merging it does not pull anything else from the Kielipankki-korp-backend repo.) Also move the script to subdirectory `korp-tools` and rename it to `korp-corpus-configs-json2yaml`.

The script will be further developed in this repo and removed from Kielipankki-korp-backend.