### PR TITLE
`korp-mysql-import`: Explicitly kill process writing to FIFO

### DIFF
--- a/scripts/korp-mysql-import.sh
+++ b/scripts/korp-mysql-import.sh
@@ -6,7 +6,12 @@
 # For more information, run korp-mysql-import.sh --help
 
 # TODO:
-# - Support importing to table corpus_info
+# - Move some MySQL functions to shlib/mysql.sh.
+# - Make --prepare-tables the default.
+# - Maybe remove support for long-obsolete "old" relations table
+#   format.
+# - Add function comments.
+# - Modernize code in places.
 
 
 progname=`basename $0`


### PR DESCRIPTION
Modify `korp-mysql-import.sh` to explicitly kill the process decompressing TSV files to FIFO for `mysql` to read if it has not exited in order to try to avoid sometimes leaving hanging processes behind (see #27). However, it is uncertain if this works or is enough to avoid hanging processes.

Also fix reporting the number of rows in a table when tables with the same name are in multiple databases.

Also some updates to the code:
1. Process options with `shlib` option processing facilities.
2. Declare `local` variables.
3. Always use spaces for indentation.