### PR TITLE
`korp-install-corpora.sh`: Always wait one minute between load checks

### DIFF
--- a/scripts/korp-install-corpora.sh
+++ b/scripts/korp-install-corpora.sh
@@ -65,6 +65,7 @@ load-limit=LIMIT "$load_limit"
     install corpus data only if the CPU load is below LIMIT (a
     positive integer); otherwise wait for the load to decrease;
     checked before each corpus package and database table file
+    (default: $load_limit)
 n|dry-run
     only report corpus packages that would be installed, but do not
     actually install them


### PR DESCRIPTION
Changes related to CPU load checking in `korp-install-corpora.sh`:

1. If the CPU load exceeds the load limit, always wait for only one minute before checking the load the next time. (Previously, a heuristic was used that often waited for much longer if the load was high.)
2. With option `--times`, output a timestamp before the message on waiting for the CPU load to decrease.
3. Check that the load limit specified as the argument of `--load-limit` is a positive integer; if not, exit with an error.