### PR TITLE
Improve VRT Tools module `libvrt.argtypes`

### DIFF
--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -194,6 +194,234 @@ def attr_regex_list_individual_value(s):
     return [(regex, value) for regex in attr_regex_list_individual(regex_list)]
 
 
+def check_unique(values, values_name='values'):
+    """Raise `ArgumentTypeError` if `values` contains duplicates.
+
+    The error message uses `values_name` to indicate what kind of
+    values are in question (default ``values``).
+    """
+    dupls = find_duplicates(values)
+    if dupls:
+        raise ArgumentTypeError(
+            f'duplicate {values_name}: ' + ', '.join(dupls))
+    return values
+
+
+def obtain_check_unique(values_name='values'):
+    """Return a function checking that the values of an iterable are unique.
+
+    The returned function takes one argument (an iterable). In case of
+    duplicate values, the error message uses `values_name`.
+    """
+    return lambda values: check_unique(values, values_name)
+
+
+def obtain_check_match(regex, value_name='value'):
+    """Return a function checking that the argument matches `regex`.
+
+    The returned function takes one argument (`str`), to be checked
+    for matching `regex`. If it does not match, the function raises
+    `ArgumentTypeError` with a message using `value_name`.
+    """
+
+    def _check_match(value):
+        if not re.fullmatch(regex, value):
+            raise ArgumentTypeError(f'invalid {value_name}: {value}')
+        return value
+
+    return _check_match
+
+
+# TODO: Perhaps move the following function to a library module for
+# functional programming utilites.
+
+def compose_unary_rev(funcs, get_func=None):
+    """Return a (reverse) composition of unary functions in iterable `funcs`.
+
+    For a value ``[f1, f2, f3]``, return a function effectively
+    working as ``f3(f2(f1(x)))`` (functions are applied in the order
+    they are listed). If `get_func` is not `None`, get the actual
+    functions to be composed by calling `get_func(f)` for each item
+    `f` in `funcs`.
+    """
+    get_func = get_func or (lambda x: x)
+    if len(funcs) == 1:
+        return get_func(funcs[0])
+    else:
+        return lambda x: compose_unary_rev(funcs[1:], get_func)(
+            get_func(funcs[0])(x))
+
+
+def list_opts(seps=None, process_item=None, process_result=None,
+              return_bytes=False, item_name='item'):
+    """Return argument type function for a list of values, with options.
+
+    Return an argument type function for a list of values separated by
+    any of the characters in `seps` (`str`), each item processed with
+    `process_item` and the whole result processed with
+    `process_result`. The result is a list. If `return_bytes` ==
+    `True`, convert the items to `bytes`. `item_name` is used in
+    `ArgumentTypeError` messages.
+
+    `process_item` can be a function of one `str` argument, a regular
+    expression (`str`) or a list whose items are either of those. A
+    function can return a modified value or check that the value is
+    appropriate and return the value intact or raise
+    `ArgumentTypeError` for an invalid value. A regular expression
+    checks that the value fully matches the expression. If the value
+    is a list, the functions are applied to the item in the order they
+    are in the list, each function applied to the value returned by
+    the previous one.
+
+    `process_result` is similar to `process_item` but the functions
+    take a list argument and return a list, and regular expressions
+    are not supported.
+    """
+
+    def obtain_processor(process_value):
+        """Return a function for processing values, based on `process_value`.
+
+        If `process_value` is a callable, it is returned as such. If
+        it is a list (of functions), return a composition of the
+        functions, first function innermost. Otherwise, return an
+        identity function. The functions should take one `str`
+        argument and return the value (modified or intact) or raise
+        `ArgumentTypeError`.
+        """
+        if isinstance(process_value, list):
+            return compose_unary_rev(process_value, obtain_processor)
+        elif callable(process_value):
+            return process_value
+        else:
+            return lambda val: val
+
+    def obtain_item_processor(process_value):
+        """Return a function for processing items, based on `process_value`.
+
+        Similar to `obtain_processor` but process_value (or its items)
+        can also be regular expressions, in which case it is tested
+        that a value fully matches the expression.
+        """
+        if isinstance(process_value, list):
+            return compose_unary_rev(process_value, obtain_item_processor)
+        elif isinstance(process_value, str):
+            return obtain_check_match(process_value, item_name)
+        else:
+            return obtain_processor(process_value)
+
+    # If the result should be converted to bytes, append encoding
+    # function to process_item
+    if return_bytes:
+        process_item.append(encode_utf8)
+    process_item = obtain_item_processor(process_item)
+    process_result = obtain_processor(process_result)
+    if seps is None:
+        seps = ', '
+
+    def _list(s):
+        """Return a list from `s`.
+
+        The list is processed according to arguments passed to the
+        outer function.
+        """
+        if seps == '':
+            return process_item(s)
+        else:
+            return process_result([process_item(item)
+                                   for item in re.split(fr'[{seps}]+', s)])
+
+    return _list
+
+
+def keylist_valuelist_opts(
+        key_seps=None, process_key=None, process_keylist=None,
+        default_key=None, strip_key=False, key_name='key',
+        value_seps=None, process_value=None, process_valuelist=None,
+        default_value=None, strip_value=False, value_name='value',
+        key_value_seps=None, return_bytes=False, arg_type_name=None):
+    """Return argument type function for a pair of lists, with options.
+
+    Return an argument type function converting a string to a pair of
+    lists (keys and values), list of values separated by any number of
+    any of the characters in `key_value_seps` (`str`). If
+    `key_value_seps` is `""`, return only a list of values (a single
+    `list`).
+
+    Items in the list of keys and values are separated by any of the
+    characters in `key_seps` and `value_seps` (`str`), respectively,
+    each key and value processed with `process_key` and
+    `process_value`, respectively, and the whole lists of keys and
+    values processed with `process_keylist` and `process_valuelist`
+    (see below for more details). If `strip_key` or `strip_value` is
+    `True`, strip spaces from the beginning and end of the list of
+    keys or values, respectively. `key_name` and `value_name` are used
+    in `ArgumentTypeError` messages.
+
+    If the argument string does not contain any character in
+    `key_value_seps`, use `default_key` as the key if specified or
+    `default_value` as the value if specified. If neither is
+    specified, raise an `ArgumentTypeError`, whose message refers to
+    `arg_type_name` if not `None`.
+
+    `process_key` and `process_value` can be functions of one `str`
+    argument, regular expressions (`str`) or lists whose items are
+    either of those. A function can return a modified value or check
+    that the value is appropriate and return the value intact or raise
+    `ArgumentTypeError` for an invalid value. A regular expression
+    checks that the value fully matches the expression. If the value
+    is a list, the functions are applied to the item in the order they
+    are in the list, each function applied to the value returned by
+    the previous one.
+
+    `process_keylist` and `process_valuelist` are similar to
+    `process_key` and `process_value` but the functions take a list
+    argument and return a list, and regular expressions are not
+    supported.
+
+    If `return_bytes` is `True`, convert all the items in the lists of
+    keys and values to `bytes`.
+    """
+
+    def error(msg):
+        raise ArgumentTypeError(
+            msg + (f' in {arg_type_name}' if arg_type_name is not None else ''))
+
+    def strip_if(s, cond):
+        return s.strip() if cond else s
+
+    if key_value_seps is None:
+        key_value_seps = ':='
+
+    def _keylist_valuelist(s):
+        if key_value_seps == '':
+            return list_opts(
+                process_item=process_value, seps=value_seps,
+                process_result=process_valuelist, item_name=value_name,
+                return_bytes=return_bytes)(strip_if(s, strip_value))
+        else:
+            parts = re.split(fr'[{key_value_seps}]+', s, 1)
+            if len(parts) == 1:
+                if default_key is not None:
+                    parts = [default_key, parts[0]]
+                elif default_value is not None:
+                    parts = [parts[0], default_value]
+                else:
+                    error(f'no {key_name}-{value_name} separator ('
+                          + ', '.join(f'"{c}"' for c in key_value_seps) + ')')
+            return (list_opts(process_item=process_key, seps=key_seps,
+                              process_result=process_keylist,
+                              item_name=key_name,
+                              return_bytes=return_bytes)(
+                                  strip_if(parts[0], strip_key)),
+                    list_opts(process_item=process_value, seps=value_seps,
+                              process_result=process_valuelist,
+                              item_name=value_name,
+                              return_bytes=return_bytes)(
+                                  strip_if(parts[1], strip_value)))
+
+    return _keylist_valuelist
+
+
 def attr_value_opts(attrname_regex=None, attrname_prefix=None,
                     attrname_suffix=None, sepchars=None, strip_value=False,
                     return_bytes=False):

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -155,3 +155,22 @@ def attr_regex_list_combined_value(s):
         s = '.+' + s
     regex_list, _, value = s.partition(':')
     return (attr_regex_list_combined(regex_list), encode_utf8(value))
+
+
+def attr_value(s):
+    """Argument type function for attribute name and string value.
+
+    s is of the form attrname(=|:)str. Whitespace around attrname is
+    stripped, whereas that around str is preserved.
+
+    Return a pair (attrname, str), both as bytes.
+    """
+    mo = re.match(r'\s*([_a-z][_a-z0-9]*)\s*[:=](.*)', s)
+    if not mo:
+        if ':' not in s and '=' not in s:
+            msg = 'no ":" nor "="'
+        else:
+            attrname, val = re.split(r'[:=]', s, 1)
+            msg = f'invalid attribute name "{attrname.strip()}"'
+        raise ArgumentTypeError(f'{msg} in attribute-value specification: {s}')
+    return (encode_utf8(mo.group(1)), encode_utf8(mo.group(2)))

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -133,6 +133,26 @@ def attr_regex_list_individual(s):
     return [re.compile(regex) for regex in _attr_regex_list_base(s)]
 
 
+def _attr_regex_list_value_base(s):
+    """Base argument type function for attribute regex list and string value.
+
+    s is of the form [[attr_regex_list]:]str, where attr_regex_list is
+    a list of attribute name regular expressions, separated by commas
+    or spaces, and str is a string value. If attr_regex_list is
+    omitted, default to ".+"; the colon can then also be omitted
+    unless str contains a colon.
+
+    Return a pair (attr_regex_list, str), with str encoded as UTF-8.
+    attr_regex_list is str.
+    """
+    if ':' not in s:
+        s = '.+:' + s
+    if s[0] == ':':
+        s = '.+' + s
+    regex_list, _, value = s.partition(':')
+    return (regex_list, encode_utf8(value))
+
+
 def attr_regex_list_combined_value(s):
     """Argument type function for attribute regex list and string value.
 
@@ -149,12 +169,8 @@ def attr_regex_list_combined_value(s):
     Raise ArgumentTypeError if the attribute regex list contains
     duplicates or if a regex is invalid.
     """
-    if ':' not in s:
-        s = '.+:' + s
-    if s[0] == ':':
-        s = '.+' + s
-    regex_list, _, value = s.partition(':')
-    return (attr_regex_list_combined(regex_list), encode_utf8(value))
+    regex_list, value = _attr_regex_list_value_base(s)
+    return (attr_regex_list_combined(regex_list), value)
 
 
 def attr_value_str(s):

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -157,13 +157,13 @@ def attr_regex_list_combined_value(s):
     return (attr_regex_list_combined(regex_list), encode_utf8(value))
 
 
-def attr_value(s):
+def attr_value_str(s):
     """Argument type function for attribute name and string value.
 
     s is of the form attrname(=|:)str. Whitespace around attrname is
     stripped, whereas that around str is preserved.
 
-    Return a pair (attrname, str), both as bytes.
+    Return a pair (attrname, str), both as str.
     """
     mo = re.match(r'\s*([_a-z][_a-z0-9]*)\s*[:=](.*)', s)
     if not mo:
@@ -173,4 +173,13 @@ def attr_value(s):
             attrname, val = re.split(r'[:=]', s, 1)
             msg = f'invalid attribute name "{attrname.strip()}"'
         raise ArgumentTypeError(f'{msg} in attribute-value specification: {s}')
-    return (encode_utf8(mo.group(1)), encode_utf8(mo.group(2)))
+    return (mo.group(1), mo.group(2))
+
+
+def attr_value(s):
+    """Argument type function for attribute name and string value.
+
+    Similar to attr_value but return a pair (attrname, str), both as
+    bytes.
+    """
+    return tuple(encode_utf8(val) for val in attr_value_str(s))

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -173,6 +173,27 @@ def attr_regex_list_combined_value(s):
     return (attr_regex_list_combined(regex_list), value)
 
 
+def attr_regex_list_individual_value(s):
+    """Argument type function for attribute regex list and string value.
+
+    s is of the form [[attr_regex_list]:]str, where attr_regex_list is
+    a list of attribute name regular expressions, separated by commas
+    or spaces, and str is a string value. If attr_regex_list is
+    omitted, default to ".+"; the colon can then also be omitted
+    unless str contains a colon.
+
+    Return a list of pairs [(compiled_regex, str)], where each
+    compiled_regex is a compiled regular expression (bytes) of one of
+    the items in attr_regex_list and str is the input str encoded as
+    UTF-8 bytes (the same for all pairs).
+
+    Raise ArgumentTypeError if the attribute regex list contains
+    duplicates or if a regex is invalid.
+    """
+    regex_list, value = _attr_regex_list_value_base(s)
+    return [(regex, value) for regex in attr_regex_list_individual(regex_list)]
+
+
 def attr_value_str(s):
     """Argument type function for attribute name and string value.
 

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -502,6 +502,54 @@ def attr_value(s):
     return attr_value_opts(return_bytes=True)(s)
 
 
+def attr_template_regex_list(s):
+    """Argument type for attribute name template and attribute regex list.
+
+    s is of the form TEMPLATE(=|:)REGEX_LIST, where TEMPLATE is an
+    attribute name template containing exactly one '{}' placeholder
+    (and otherwise forming a valid attribute name), and REGEX_LIST is
+    a comma- or space-separated list of attribute name regular
+    expressions.
+
+    Return a pair (template, regexes), where template is TEMPLATE
+    encoded as UTF-8 bytes (with '{}' preserved) and regexes is a
+    list of compiled regular expressions (for bytes), one for each
+    item in REGEX_LIST.
+
+    Raise ArgumentTypeError if:
+    - s contains no '=' or ':' separator,
+    - TEMPLATE does not contain exactly one '{}',
+    - TEMPLATE (with '{}' replaced by a placeholder) is not a valid
+      attribute name,
+    - REGEX_LIST is empty, or
+    - REGEX_LIST contains duplicates or an invalid regular expression.
+    """
+    sep_mo = re.search(r'[=:]', s)
+    if not sep_mo:
+        raise ArgumentTypeError(
+            'no name-value separator (":", "=") in'
+            f' attribute-template-regex-list specification: {s}')
+    template = s[:sep_mo.start()].strip()
+    regex_list_str = s[sep_mo.end():]
+    count = template.count('{}')
+    if count == 0:
+        raise ArgumentTypeError(
+            f'attribute name template must contain "{{}}": {template}')
+    if count > 1:
+        raise ArgumentTypeError(
+            'attribute name template must contain exactly one'
+            f' "{{}}": {template}')
+    # Validate by replacing '{}' with a placeholder letter
+    if not re.fullmatch(r'[_a-z][_a-z0-9]*', template.replace('{}', 'x')):
+        raise ArgumentTypeError(
+            f'invalid attribute name template: {template}')
+    regexes = attr_regex_list_individual(regex_list_str)
+    if not regexes:
+        raise ArgumentTypeError(
+            f'attribute regex list must not be empty: {s}')
+    return (template.encode('utf-8'), regexes)
+
+
 def struct_attr_regex(s: str) -> tuple[bytes, bytes, re.Pattern[bytes]]:
     """Argument type function for structure name, attribute name, and regex.
 

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -259,9 +259,13 @@ def list_opts(seps=None, process_item=None, process_result=None,
     Return an argument type function for a list of values separated by
     any of the characters in `seps` (`str`), each item processed with
     `process_item` and the whole result processed with
-    `process_result`. The result is a list. If `return_bytes` ==
-    `True`, convert the items to `bytes`. `item_name` is used in
+    `process_result`. The result is a list. `item_name` is used in
     `ArgumentTypeError` messages.
+
+    `seps` defaults to ``', '`` (comma and space), meaning items are
+    separated by any combination of commas and spaces. If `seps` is
+    ``''``, no splitting is done: `process_item` is applied to the
+    whole input string and its return value is returned directly.
 
     `process_item` can be a function of one `str` argument, a regular
     expression (`str`) or a list whose items are either of those. A
@@ -276,6 +280,11 @@ def list_opts(seps=None, process_item=None, process_result=None,
     `process_result` is similar to `process_item` but the functions
     take a list argument and return a list, and regular expressions
     are not supported.
+
+    If `return_bytes` is `True`, `encode_utf8` is appended to the
+    item processing pipeline (after any `process_item` steps), so
+    each item in the result list is converted to `bytes`. Works
+    regardless of the type of `process_item`.
     """
 
     def obtain_processor(process_value):
@@ -309,10 +318,16 @@ def list_opts(seps=None, process_item=None, process_result=None,
         else:
             return obtain_processor(process_value)
 
-    # If the result should be converted to bytes, append encoding
-    # function to process_item
+    # If the result should be converted to bytes, append the encoding
+    # function to the item processing pipeline. Build a new list (or
+    # wrap in one) rather than mutating a caller-provided list.
     if return_bytes:
-        process_item.append(encode_utf8)
+        if isinstance(process_item, list):
+            process_item = list(process_item) + [encode_utf8]
+        elif process_item is None:
+            process_item = encode_utf8
+        else:
+            process_item = [process_item, encode_utf8]
     process_item = obtain_item_processor(process_item)
     process_result = obtain_processor(process_result)
     if seps is None:

--- a/vrt-tools/libvrt/argtypes.py
+++ b/vrt-tools/libvrt/argtypes.py
@@ -485,3 +485,48 @@ def attr_value(s):
     bytes.
     """
     return attr_value_opts(return_bytes=True)(s)
+
+
+def struct_attr_regex(s: str) -> tuple[bytes, bytes, re.Pattern[bytes]]:
+    """Argument type function for structure name, attribute name, and regex.
+
+    Parses a string of the form ``STRUCT:ATTR=REGEX``, where ``STRUCT``
+    is a structure (element) name, ``ATTR`` is an attribute name within
+    that structure, and ``REGEX`` is a regular expression to be fully
+    matched against the attribute value.
+
+    Args:
+        s: Argument string of the form ``STRUCT:ATTR=REGEX``.
+
+    Returns:
+        A 3-tuple ``(struct, attr, compiled_regex)``, where ``struct``
+        and ``attr`` are UTF-8 encoded bytes and ``compiled_regex`` is
+        a compiled regular expression for bytes.
+
+    Raises:
+        ArgumentTypeError: If ``s`` is not a valid ``STRUCT:ATTR=REGEX``
+            specification.
+    """
+    # Split on ':' to separate structure name from ATTR=REGEX
+    try:
+        struct_str, attr_regex_str = attr_value_opts(
+            sepchars=':', return_bytes=False)(s)
+    except ArgumentTypeError:
+        raise ArgumentTypeError(
+            f'invalid struct:attr=regex specification: {s!r}')
+    # Split on '=' to separate attribute name from the regex
+    try:
+        attr_str, regex_str = attr_value_opts(
+            sepchars='=', return_bytes=False)(attr_regex_str)
+    except ArgumentTypeError:
+        raise ArgumentTypeError(
+            f'invalid attr=regex part {attr_regex_str!r}'
+            f' in struct:attr=regex specification: {s!r}')
+    # Compile the regex for matching bytes attribute values
+    try:
+        compiled = re.compile(regex_str.encode('UTF-8'))
+    except re.error as e:
+        raise ArgumentTypeError(
+            f'invalid regular expression {regex_str!r}'
+            f' in struct:attr=regex specification: {s!r}: {e}')
+    return (struct_str.encode('UTF-8'), attr_str.encode('UTF-8'), compiled)

--- a/vrt-tools/tests/libvrt/test_argtypes.py
+++ b/vrt-tools/tests/libvrt/test_argtypes.py
@@ -274,6 +274,90 @@ class TestAttrRegexListCombinedValue:
             in str(excinfo.value))
 
 
+class TestAttrRegexListIndividualValue:
+
+    """Tests for vrtlib.argtypes function attr_regex_list_individual_value."""
+
+    # CHECK: This class is copied and modified from
+    # TestAttrRegexListCombinedValue. Could the two classes be
+    # combined or the repetition otherwise be reduced?
+
+    @pytest.mark.parametrize(
+        'input,expected', [
+            # Value only
+            ('', [(b'.+', b'')]),
+            ('a', [(b'.+', b'a')]),
+            ('a,b', [(b'.+', b'a,b')]),
+            ('a,a', [(b'.+', b'a,a')]),
+            ('a b', [(b'.+', b'a b')]),
+            (' a   b  ', [(b'.+', b' a   b  ')]),
+            # Value prefixed by a colon
+            (':a', [(b'.+', b'a')]),
+            # Value containing a colon
+            ('::', [(b'.+', b':')]),
+            (':a:a', [(b'.+', b'a:a')]),
+            # Regular expression (list) with a value
+            ('a:a:a', [(b'a', b'a:a')]),
+            ('a,b:x', [(b'a', b'x'), (b'b', b'x')]),
+            ('a b:x', [(b'a', b'x'), (b'b', b'x')]),
+            (' a   b  :x', [(b'a', b'x'), (b'b', b'x')]),
+            (' a ,  b , : x ', [(b'a', b' x '), (b'b', b' x ')]),
+            (',a,,,b,,,:x', [(b'a', b'x'), (b'b', b'x')]),
+            ('_,a:x', [(b'_', b'x'), (b'a', b'x')]),
+            ('_.*,a:x', [(b'_.*', b'x'), (b'a', b'x')]),
+            ('.*2,a:x', [(b'.*2', b'x'), (b'a', b'x')]),
+            ('a.,b.+,c[de],f(g|hi)j:x', [
+                (b'a.', b'x'),
+                (b'b.+', b'x'),
+                (b'c[de]', b'x'),
+                (b'f(g|hi)j', b'x'),
+            ]),
+        ]
+    )
+    def test_attr_regex_list_individual_value(self, input, expected):
+        """Test attr_regex_list_individual_value() with various inputs."""
+        result = at.attr_regex_list_individual_value(input)
+        assert len(result) == len(expected)
+        for i, exp_item in enumerate(expected):
+            assert (result[i][0].pattern, result[i][1]) == exp_item
+
+    @pytest.mark.parametrize(
+        'input,dupl', [
+            ('a,a:x', 'a'),
+            ('a a:x', 'a'),
+            ('a,b,a:x', 'a'),
+            ('a.b,c, a.b:x', 'a.b'),
+        ]
+    )
+    def test_attr_regex_list_individual_value_dupl(self, input, dupl):
+        """Test attr_regex_list_individual_value() with duplicate values."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            assert at.attr_regex_list_individual_value(input)
+        assert (f'duplicate attribute name regular expressions: {dupl}'
+                in str(excinfo.value))
+
+    @pytest.mark.parametrize(
+        'input,invalid,errmsg', [
+            ('a,+.:x', '+.', 'nothing to repeat at position 0'),
+            ('a,(a:x', '(a',
+             'missing ), unterminated subpattern at position 0'),
+            ('a,a):x', 'a)', 'unbalanced parenthesis at position 1'),
+            ('a,[a:x', '[a', 'unterminated character set at position 0'),
+            ('a,aäb:x', 'aäb', 'contains non-ASCII characters'),
+            ('a,a\x01b:x', 'a\x01b', 'contains non-printable characters'),
+            ('a,aUb:x', 'aUb', 'contains upper-case characters'),
+        ]
+    )
+    def test_attr_regex_list_individual_value_invalid(
+            self, input, invalid, errmsg):
+        """Test attr_regex_list_individual_value() with invalid values."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            assert at.attr_regex_list_individual_value(input)
+        assert (
+            f'invalid attribute name regular expression: "{invalid}": {errmsg}'
+            in str(excinfo.value))
+
+
 class TestAttrValue:
 
     """Tests for vrtlib.argtypes functions attr_value and attr_value_str."""

--- a/vrt-tools/tests/libvrt/test_argtypes.py
+++ b/vrt-tools/tests/libvrt/test_argtypes.py
@@ -542,6 +542,287 @@ class TestAttrValue:
             result = attr_value_func(input)
 
 
+class TestListOpts:
+
+    """Tests for libvrt.argtypes function list_opts."""
+
+    # Basic splitting
+
+    @pytest.mark.parametrize(
+        'seps,input,expected', [
+            # Default seps split on commas and spaces
+            (None, 'a', ['a']),
+            (None, 'a,b', ['a', 'b']),
+            (None, 'a b', ['a', 'b']),
+            (None, 'a,b,c', ['a', 'b', 'c']),
+            # Multiple adjacent separators are treated as one
+            (None, 'a,,b', ['a', 'b']),
+            (None, 'a, b', ['a', 'b']),
+            # Custom separators
+            (':', 'a:b:c', ['a', 'b', 'c']),
+            ('|', 'a|b', ['a', 'b']),
+            ('|:', 'a|b:c', ['a', 'b', 'c']),
+        ]
+    )
+    def test_split(self, seps, input, expected):
+        """Test list_opts splitting with default and custom separators."""
+        assert at.list_opts(seps=seps)(input) == expected
+
+    def test_seps_empty_no_split(self):
+        """Test list_opts with seps='' applies process_item to whole string."""
+        # When seps='', the whole string is passed to process_item directly
+        assert at.list_opts(seps='')('hello world') == 'hello world'
+
+    def test_seps_empty_with_process_item(self):
+        """Test list_opts with seps='' and a process_item function."""
+        assert at.list_opts(seps='', process_item=str.upper)('hello') == 'HELLO'
+
+    # process_item as callable
+
+    def test_process_item_function(self):
+        """Test list_opts with process_item as a callable."""
+        assert at.list_opts(process_item=str.upper)('a,b') == ['A', 'B']
+
+    # process_item as regex
+
+    def test_process_item_regex_valid(self):
+        """Test list_opts with process_item as a regex; valid items pass."""
+        assert at.list_opts(process_item=r'[a-z]+')('a,b') == ['a', 'b']
+
+    def test_process_item_regex_invalid_item(self):
+        """Test list_opts with process_item regex; invalid item raises error."""
+        with pytest.raises(ArgumentTypeError, match='invalid item: 1'):
+            at.list_opts(process_item=r'[a-z]+')('a,1')
+
+    def test_process_item_regex_custom_item_name(self):
+        """Test list_opts item_name is used in error messages."""
+        with pytest.raises(ArgumentTypeError, match='invalid letter: 1'):
+            at.list_opts(
+                process_item=r'[a-z]+', item_name='letter')('a,1')
+
+    # process_item as list (composition)
+
+    def test_process_item_list_of_functions(self):
+        """Test list_opts with process_item as a list of callables."""
+        # Functions applied in order: upper first, then strip
+        assert at.list_opts(
+            process_item=[str.upper, str.strip])('a,b') == ['A', 'B']
+
+    def test_process_item_list_regex_and_function(self):
+        """Test list_opts with process_item as list mixing regex and callable."""
+        assert at.list_opts(
+            process_item=[r'[a-z]+', str.upper])('a,b') == ['A', 'B']
+
+    # process_result
+
+    def test_process_result_function(self):
+        """Test list_opts with process_result applied to the whole list."""
+        assert at.list_opts(process_result=sorted)('c,a,b') == ['a', 'b', 'c']
+
+    def test_process_result_list_of_functions(self):
+        """Test list_opts with process_result as a list of functions."""
+        assert at.list_opts(
+            process_result=[sorted, list])('c,a,b') == ['a', 'b', 'c']
+
+    # return_bytes — these tests expose the bug in list_opts
+
+    def test_return_bytes_no_process_item(self):
+        """Test list_opts return_bytes=True with no process_item."""
+        # Bug: currently raises AttributeError (None.append)
+        assert at.list_opts(return_bytes=True)('a,b') == [b'a', b'b']
+
+    def test_return_bytes_with_function(self):
+        """Test list_opts return_bytes=True with process_item as a function."""
+        # Bug: currently raises AttributeError (method.append)
+        assert at.list_opts(
+            process_item=str.upper, return_bytes=True)('a,b') == [b'A', b'B']
+
+    def test_return_bytes_with_regex(self):
+        """Test list_opts return_bytes=True with process_item as a regex."""
+        # Bug: currently raises AttributeError (str.append)
+        assert at.list_opts(
+            process_item=r'[a-z]+',
+            return_bytes=True)('a,b') == [b'a', b'b']
+
+    def test_return_bytes_with_list_no_mutation(self):
+        """Test list_opts return_bytes=True with process_item as list.
+
+        The original process_item list must not be mutated; encode_utf8
+        would accumulate on repeated calls otherwise.
+        """
+        process_item = [str.upper]
+        at.list_opts(process_item=process_item, return_bytes=True)('a,b')
+        # Bug: currently mutates process_item, adding encode_utf8 each time
+        assert process_item == [str.upper]
+
+    def test_return_bytes_stable_on_repeated_calls(self):
+        """Test list_opts return_bytes=True gives consistent results on repeat.
+
+        With the mutation bug a second call would try encode_utf8(bytes)
+        and crash.
+        """
+        fn = at.list_opts(return_bytes=True)
+        assert fn('a,b') == [b'a', b'b']
+        # Bug: second call fails when process_item list has been mutated
+        assert fn('c,d') == [b'c', b'd']
+
+
+class TestKeylistValuelistOpts:
+
+    """Tests for libvrt.argtypes function keylist_valuelist_opts."""
+
+    # Basic key-value splitting
+
+    @pytest.mark.parametrize(
+        'input,expected', [
+            ('a=b', (['a'], ['b'])),
+            ('a:b', (['a'], ['b'])),
+            ('a,b=x,y', (['a', 'b'], ['x', 'y'])),
+            ('a=x,y', (['a'], ['x', 'y'])),
+            ('a,b=x', (['a', 'b'], ['x'])),
+        ]
+    )
+    def test_basic(self, input, expected):
+        """Test keylist_valuelist_opts with default separators."""
+        assert at.keylist_valuelist_opts()(input) == expected
+
+    # key_value_seps='' — return only a value list
+
+    def test_empty_key_value_seps_returns_list(self):
+        """Test that key_value_seps='' returns only a value list."""
+        assert at.keylist_valuelist_opts(key_value_seps='')('a,b') == ['a', 'b']
+
+    # Custom key_value_seps
+
+    def test_custom_key_value_seps(self):
+        """Test keylist_valuelist_opts with custom key_value_seps."""
+        assert at.keylist_valuelist_opts(
+            key_value_seps='|')('a,b|x,y') == (['a', 'b'], ['x', 'y'])
+
+    # Custom key_seps / value_seps
+
+    def test_custom_key_seps(self):
+        """Test keylist_valuelist_opts with custom key_seps."""
+        assert at.keylist_valuelist_opts(
+            key_seps=':', key_value_seps='=')('a:b=x') == (['a', 'b'], ['x'])
+
+    def test_custom_value_seps(self):
+        """Test keylist_valuelist_opts with custom value_seps."""
+        assert at.keylist_valuelist_opts(
+            value_seps=':', key_value_seps='=')('a=x:y') == (['a'], ['x', 'y'])
+
+    # default_key and default_value
+
+    def test_default_key_used_when_no_separator(self):
+        """Test that default_key is used when input has no key-value sep."""
+        assert at.keylist_valuelist_opts(
+            default_key='k')('v') == (['k'], ['v'])
+
+    def test_default_value_used_when_no_separator(self):
+        """Test that default_value is used when input has no key-value sep."""
+        assert at.keylist_valuelist_opts(
+            default_value='v')('k') == (['k'], ['v'])
+
+    def test_default_key_takes_precedence_over_default_value(self):
+        """Test that default_key is preferred over default_value."""
+        assert at.keylist_valuelist_opts(
+            default_key='k',
+            default_value='v')('x') == (['k'], ['x'])
+
+    # Error: no separator and no defaults
+
+    def test_no_separator_no_defaults_raises(self):
+        """Test error raised when no sep and neither default is given."""
+        with pytest.raises(
+                ArgumentTypeError,
+                match=r'no key-value separator \(":", "="\)'):
+            at.keylist_valuelist_opts()('ab')
+
+    def test_no_separator_arg_type_name_in_error(self):
+        """Test that arg_type_name appears in the error message."""
+        with pytest.raises(ArgumentTypeError, match='in mytype'):
+            at.keylist_valuelist_opts(arg_type_name='mytype')('ab')
+
+    # strip_key and strip_value
+
+    def test_strip_key(self):
+        """Test strip_key=True strips whitespace from the key string."""
+        assert at.keylist_valuelist_opts(
+            strip_key=True)('  a  =b') == (['a'], ['b'])
+
+    def test_strip_value(self):
+        """Test strip_value=True strips whitespace from the value string."""
+        assert at.keylist_valuelist_opts(
+            strip_value=True)('a=  b  ') == (['a'], ['b'])
+
+    # return_bytes — inherits list_opts bug
+
+    def test_return_bytes(self):
+        """Test keylist_valuelist_opts return_bytes=True encodes to bytes."""
+        # Bug: currently raises AttributeError (None.append) via list_opts
+        assert at.keylist_valuelist_opts(
+            return_bytes=True)('a=b') == ([b'a'], [b'b'])
+
+    def test_return_bytes_multiple(self):
+        """Test keylist_valuelist_opts return_bytes=True with lists."""
+        assert at.keylist_valuelist_opts(
+            return_bytes=True)('a,b=x,y') == ([b'a', b'b'], [b'x', b'y'])
+
+    def test_return_bytes_stable_on_repeated_calls(self):
+        """Test return_bytes=True gives consistent results on repeat calls."""
+        fn = at.keylist_valuelist_opts(return_bytes=True)
+        assert fn('a=b') == ([b'a'], [b'b'])
+        # Bug: second call fails due to list mutation in list_opts
+        assert fn('c=d') == ([b'c'], [b'd'])
+
+    def test_return_bytes_with_process_key_function(self):
+        """Test return_bytes=True with process_key as a function."""
+        assert at.keylist_valuelist_opts(
+            process_key=str.upper, return_bytes=True)('a=b') == (
+                [b'A'], [b'b'])
+
+    # process_key, process_value
+
+    def test_process_key_function(self):
+        """Test process_key function is applied to each key item."""
+        assert at.keylist_valuelist_opts(
+            process_key=str.upper)('a,b=x') == (['A', 'B'], ['x'])
+
+    def test_process_value_function(self):
+        """Test process_value function is applied to each value item."""
+        assert at.keylist_valuelist_opts(
+            process_value=str.upper)('a=x,y') == (['a'], ['X', 'Y'])
+
+    def test_process_key_regex(self):
+        """Test process_key as a regex validates each key item."""
+        assert at.keylist_valuelist_opts(
+            process_key=r'[a-z]+')('a,b=x') == (['a', 'b'], ['x'])
+
+    def test_process_key_regex_invalid(self):
+        """Test process_key regex raises on invalid key."""
+        with pytest.raises(ArgumentTypeError, match='invalid key: 1'):
+            at.keylist_valuelist_opts(
+                process_key=r'[a-z]+', key_name='key')('1=x')
+
+    def test_process_value_regex_invalid(self):
+        """Test process_value regex raises on invalid value."""
+        with pytest.raises(ArgumentTypeError, match='invalid value: 1'):
+            at.keylist_valuelist_opts(
+                process_value=r'[a-z]+', value_name='value')('a=1')
+
+    # process_keylist, process_valuelist
+
+    def test_process_keylist_function(self):
+        """Test process_keylist is applied to the full key list."""
+        assert at.keylist_valuelist_opts(
+            process_keylist=sorted)('b,a=x') == (['a', 'b'], ['x'])
+
+    def test_process_valuelist_function(self):
+        """Test process_valuelist is applied to the full value list."""
+        assert at.keylist_valuelist_opts(
+            process_valuelist=sorted)('a=y,x') == (['a'], ['x', 'y'])
+
+
 class TestStructAttrRegex:
 
     """Tests for libvrt.argtypes function struct_attr_regex."""

--- a/vrt-tools/tests/libvrt/test_argtypes.py
+++ b/vrt-tools/tests/libvrt/test_argtypes.py
@@ -892,3 +892,143 @@ class TestStructAttrRegex:
         with pytest.raises(ArgumentTypeError,
                            match='struct:attr=regex'):
             at.struct_attr_regex(input)
+
+
+class TestAttrTemplateRegexList:
+
+    """Tests for libvrt.argtypes function attr_template_regex_list."""
+
+    # Helper to extract comparable data from a result
+    @staticmethod
+    def _result(s):
+        template, regexes = at.attr_template_regex_list(s)
+        return (template, [r.pattern for r in regexes])
+
+    @pytest.mark.parametrize(
+        'input,expected_template,expected_patterns', [
+            # Minimal template and single regex
+            ('new_{}=a', b'new_{}', [b'a']),
+            # Colon as separator
+            ('new_{}:a', b'new_{}', [b'a']),
+            # {} at the start
+            ('{}=a', b'{}', [b'a']),
+            # {} in the middle
+            ('pre_{}suf=a', b'pre_{}suf', [b'a']),
+            # {} after underscore prefix
+            ('_{}=a', b'_{}', [b'a']),
+            # Template with digits after {}
+            ('{}_2=a', b'{}_2', [b'a']),
+            # Multiple regexes, comma-separated
+            ('new_{}=a,b', b'new_{}', [b'a', b'b']),
+            # Multiple regexes, space-separated
+            ('new_{}=a b', b'new_{}', [b'a', b'b']),
+            # Mixed comma/space separators in regex list
+            ('new_{}=a, b', b'new_{}', [b'a', b'b']),
+            # Whitespace around template is stripped
+            (' new_{} =a', b'new_{}', [b'a']),
+            # Regex with quantifier
+            ('new_{}=a.*', b'new_{}', [b'a.*']),
+            # Regex with alternation group
+            ('new_{}=f(g|hi)j', b'new_{}', [b'f(g|hi)j']),
+        ]
+    )
+    def test_valid(self, input, expected_template, expected_patterns):
+        """Test attr_template_regex_list() with valid inputs."""
+        assert self._result(input) == (expected_template, expected_patterns)
+
+    @pytest.mark.parametrize(
+        'input', [
+            'new_x_a',      # no separator at all
+            'new_{}',       # no separator (no = or :)
+        ]
+    )
+    def test_no_separator(self, input):
+        """Test attr_template_regex_list() raises when separator is missing."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert ('no name-value separator (":", "=") in'
+                ' attribute-template-regex-list specification'
+                in str(excinfo.value))
+
+    @pytest.mark.parametrize(
+        'input,template', [
+            ('new_x=a', 'new_x'),
+            ('prefix=a', 'prefix'),
+            (' no_brace =a', 'no_brace'),
+        ]
+    )
+    def test_no_placeholder(self, input, template):
+        """Test error when template contains no '{}'."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert (f'attribute name template must contain "{{}}": {template}'
+                in str(excinfo.value))
+
+    @pytest.mark.parametrize(
+        'input,template', [
+            ('{}_{}=a', '{}_{}'),
+            ('{}{}=a', '{}{}'),
+        ]
+    )
+    def test_multiple_placeholders(self, input, template):
+        """Test error when template contains more than one '{}'."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert ('attribute name template must contain exactly one "{}": '
+                + template in str(excinfo.value))
+
+    @pytest.mark.parametrize(
+        'input,template', [
+            # Starts with a digit
+            ('1{}=a', '1{}'),
+            # Contains uppercase
+            ('NEW_{}=a', 'NEW_{}'),
+            # Contains a dot
+            ('a.{}=a', 'a.{}'),
+            # Starts with {}; {} replaced by x gives 'x', but suffix invalid
+            ('{}!=a', '{}!'),
+        ]
+    )
+    def test_invalid_template(self, input, template):
+        """Test error when template is not a valid attribute name."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert (f'invalid attribute name template: {template}'
+                in str(excinfo.value))
+
+    @pytest.mark.parametrize(
+        'input,dupl', [
+            ('new_{}=a,a', 'a'),
+            ('new_{}=a a', 'a'),
+            ('new_{}=a,b,a', 'a'),
+        ]
+    )
+    def test_duplicate_regex(self, input, dupl):
+        """Test error when regex list contains duplicates."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert (f'duplicate attribute name regular expressions: {dupl}'
+                in str(excinfo.value))
+
+    def test_empty_regex_list(self):
+        """Test error when regex list is empty."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list('new_{}=')
+        assert 'attribute regex list must not be empty' in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        'input,invalid,errmsg', [
+            ('new_{}=+.', '+.', 'nothing to repeat at position 0'),
+            ('new_{}=(a', '(a',
+             'missing ), unterminated subpattern at position 0'),
+            ('new_{}=aUb', 'aUb', 'contains upper-case characters'),
+            ('new_{}=aäb', 'aäb', 'contains non-ASCII characters'),
+        ]
+    )
+    def test_invalid_regex(self, input, invalid, errmsg):
+        """Test error when regex list contains an invalid regex."""
+        with pytest.raises(ArgumentTypeError) as excinfo:
+            at.attr_template_regex_list(input)
+        assert (
+            f'invalid attribute name regular expression: "{invalid}": {errmsg}'
+            in str(excinfo.value))

--- a/vrt-tools/tests/libvrt/test_argtypes.py
+++ b/vrt-tools/tests/libvrt/test_argtypes.py
@@ -540,3 +540,74 @@ class TestAttrValue:
                            match=(f'invalid attribute name "{invalid}" in'
                                   f' attribute-value specification: {input}$')):
             result = attr_value_func(input)
+
+
+class TestStructAttrRegex:
+
+    """Tests for libvrt.argtypes function struct_attr_regex."""
+
+    @pytest.mark.parametrize(
+        'input,expected_struct,expected_attr,expected_regex_pattern', [
+            ('text:a=foo', b'text', b'a', b'foo'),
+            ('paragraph:type=intro', b'paragraph', b'type', b'intro'),
+            # Regex with alternation
+            ('paragraph:type=intro|body', b'paragraph', b'type', b'intro|body'),
+            # Regex with quantifier
+            ('sentence:id=.+', b'sentence', b'id', b'.+'),
+            # Regex containing '='
+            ('text:a=x=y', b'text', b'a', b'x=y'),
+            # Empty regex
+            ('text:a=', b'text', b'a', b''),
+            # Attribute name with underscores and digits
+            ('text:my_attr2=val', b'text', b'my_attr2', b'val'),
+        ]
+    )
+    def test_struct_attr_regex_valid(
+            self, input, expected_struct, expected_attr,
+            expected_regex_pattern):
+        """Test struct_attr_regex() with valid inputs."""
+        struct, attr, regex = at.struct_attr_regex(input)
+        assert struct == expected_struct
+        assert attr == expected_attr
+        assert regex.pattern == expected_regex_pattern
+
+    @pytest.mark.parametrize(
+        'input', [
+            'text',       # no ':' separator
+            'textfoo',    # no ':' separator
+            ':a=foo',     # missing struct name
+            '1text:a=foo',  # struct name starting with digit
+            'Text:a=foo',   # struct name with uppercase
+        ]
+    )
+    def test_struct_attr_regex_invalid_struct(self, input):
+        """Test struct_attr_regex() with invalid structure name."""
+        with pytest.raises(ArgumentTypeError,
+                           match='struct:attr=regex'):
+            at.struct_attr_regex(input)
+
+    @pytest.mark.parametrize(
+        'input', [
+            'text:afoo',    # no '=' separator in attr part
+            'text:A=foo',   # attr name with uppercase
+            'text:1a=foo',  # attr name starting with digit
+            'text::a=foo',  # double colon, attr part starts with ':'
+        ]
+    )
+    def test_struct_attr_regex_invalid_attr(self, input):
+        """Test struct_attr_regex() with invalid attribute name."""
+        with pytest.raises(ArgumentTypeError,
+                           match='struct:attr=regex'):
+            at.struct_attr_regex(input)
+
+    @pytest.mark.parametrize(
+        'input', [
+            r'text:a=[invalid',   # unclosed bracket
+            r'text:a=(*)',        # invalid quantifier
+        ]
+    )
+    def test_struct_attr_regex_invalid_regex(self, input):
+        """Test struct_attr_regex() with invalid regular expression."""
+        with pytest.raises(ArgumentTypeError,
+                           match='struct:attr=regex'):
+            at.struct_attr_regex(input)


### PR DESCRIPTION
**Description**

Add (or rather improve) the VRT Tools library module `libvrt.argtypes` containing functions that can be used as argument types in `argparse` argument specifications.

The module currently implements the following argument type functions:

- `encode_utf8`: Convert argument to UTF-8 `bytes`.

- `attrlist`: Recognize a list of unique attribute names.

- `attr_regex_list_combined`, `attr_regex_list_individual`: Recognize a list of attribute name regular expressions and return them as either a single compiled regular expression or a list of them, depending on the function.

- `attr_regex_list_combined_value`, `attr_regex_list_individual_value`: Recognize *[[attr_regex_list]*`:`*str* where *attr_regex_list* is a list of attribute name regular expressions and *str* a string value, and return either a pair or a list of pairs with compiled regular expression and `str`.

- `attr_value_opts`: Return a function to recognize an attribute name and an associated value, with a number of options affecting what exactly is recognized.

- `attr_value_str`, `attr_value`: Recognize an attribute name and a string value, separated by a `:` or `=` and returned as `str` or `bytes` (depending on the function).

In addition, the module contains a couple of other argument type functions (and helper functions) that may eventually be replaced by a different implementation.

**Notes**

- The first implementation of `libvrt.argtypes` has already been merged to `master` along with some VRT tools that use the functions, so this PR alone does not show the complete implementation of the module.

- I have a proof of concept for a more compositional approach for implementing many of the current argument type functions, to reduce the need to have so many special-purpose functions. It would probably still need some polishing (or perhaps even partial rethinking) or at least documentation and tests.