### PR TITLE
VRT Tools: Fix invalid backslash escapes

### DIFF
--- a/vrt-tools/hrt-encode-tags
+++ b/vrt-tools/hrt-encode-tags
@@ -126,7 +126,7 @@ class TagEncoder(InputProcessor):
         # space or end-of-string (a tag).
         ignore_re = re.compile(
             ((r'((?<= \S) (?:' + args.hyphens + ')+ )?'
-              + '(?: \Z | (?:' + args.spaces + ')+)')
+              + r'(?: \Z | (?:' + args.spaces + ')+)')
              if args.hyphens else
              ('(?:' + args.spaces + ')+')),
             re.VERBOSE)

--- a/vrt-tools/libvrt/nameargs.py
+++ b/vrt-tools/libvrt/nameargs.py
@@ -12,19 +12,19 @@ from libvrt.bad import BadData
 
 def nametype(arg):
     '''Approximately safe to use as a field name.'''
-    if re.fullmatch('\w+/?', arg, re.ASCII):
+    if re.fullmatch(r'\w+/?', arg, re.ASCII):
         return arg.encode('UTF-8')
     raise ArgumentTypeError('bad name: ' + repr(arg))
 
 def prefixtype(arg):
     '''Approximately safe to use as a prefix to a field name.'''
-    if re.fullmatch('\w*', arg, re.ASCII):
+    if re.fullmatch(r'\w*', arg, re.ASCII):
         return arg.encode('UTF-8')
     raise ArgumentTypeError('bad prefix: ' + repr(arg))
 
 def suffixtype(arg):
     '''Approximately safe to use as a suffix to a field name.'''
-    if re.fullmatch('\w*', arg, re.ASCII):
+    if re.fullmatch(r'\w*', arg, re.ASCII):
         return arg.encode('UTF-8')
     raise ArgumentTypeError('bad suffix: ' + repr(arg))
 

--- a/vrt-tools/libvrt/structargs.py
+++ b/vrt-tools/libvrt/structargs.py
@@ -19,7 +19,7 @@ def _structattrbagtype(text, allowany=False):
     # attrnamere also covers style "structname_attrname"
     attrnamere = f'(?:[a-zA-Z_][a-zA-Z0-9_.]*/?{anyre})'
     namere = rf'(?:{structnamere}\s*:\s*)?{attrnamere}'
-    sepre = '[,\s]+'
+    sepre = r'[,\s]+'
     text = text.strip()
     if re.fullmatch(fr'{namere}({sepre}{namere})*', text):
         return text.encode('UTF-8')

--- a/vrt-tools/libvrt/tools/hrt_check_meta.py
+++ b/vrt-tools/libvrt/tools/hrt_check_meta.py
@@ -49,7 +49,7 @@ def main(args, ins, ous):
             name = re.match(b'<([a-z._]+)', line).group(1)
             check_name(args, ous, line, name)
 
-            attr = re.findall(b'(\S+)="(.*?)"', line)
+            attr = re.findall(br'(\S+)="(.*?)"', line)
             check_attr(args, ous, line, name, attr)
             
             # print('name:', name)

--- a/vrt-tools/libvrt/tools/vrt_add_id.py
+++ b/vrt-tools/libvrt/tools/vrt_add_id.py
@@ -40,7 +40,7 @@ DEFAULT_ID_FORMATS = {
 }
 
 def affix(arg):
-    if re.fullmatch('[A-Za-z0-9_\-+/.:]*', arg):
+    if re.fullmatch(r'[A-Za-z0-9_\-+/.:]*', arg):
         return arg
     raise ArgumentTypeError('affix out of spec')
 
@@ -554,7 +554,7 @@ def check_format(fmt, elem, elem_names, elem_formatspecs, prog):
                 if formatspec[-1].isdigit():
                     formatspec += 'd'
             spec_elem = (elem if fieldname == 'id'
-                         else re.match('idnum\[(.*?)\]', fieldname).group(1))
+                         else re.match(r'idnum\[(.*?)\]', fieldname).group(1))
             elem_formatspecs[spec_elem][formatspec or ''] = True
         elif formatspec:
             # Others are string-valued; if a format specification is

--- a/vrt-tools/libvrt/tools/vrt_block_finnish_nertag.py
+++ b/vrt-tools/libvrt/tools/vrt_block_finnish_nertag.py
@@ -128,8 +128,8 @@ def ship_sentence(lines, WORD, ous):
         # This blocks lists of actual names, which is unfortunate, but
         # then a list of names is not a name, so what can one do. And
         # trollish repetition of a name has been observed.
-        re.search('( [A-ZÅÄÖ][A-ZÅÄÖa-zåäö\-/]*){20,20} ', text) or
-        re.search('( [A-ZÅÄÖ][A-ZÅÄÖ\-!?]*){12,12} ', text) or
+        re.search(r'( [A-ZÅÄÖ][A-ZÅÄÖa-zåäö\-/]*){20,20} ', text) or
+        re.search(r'( [A-ZÅÄÖ][A-ZÅÄÖ\-!?]*){12,12} ', text) or
 
         # Sequences of tokens that start with a letter and end in
         # digits have been observed (in failing sentences) as
@@ -167,19 +167,19 @@ def ship_sentence(lines, WORD, ous):
         # a sequence of &gameselect[]=DIGITS which also would have
         # been caught with just the initial & except some of those
         # were separated as their own tokens. Will this ever repeat?
-        re.search('( [A-ZÅÄÖa-zåäö#&/][A-ZÅÄÖa-zåäö0-9/,.:!=\-\[\]]*[0-9]| TX| RX){8,8} ', text) or
+        re.search(r'( [A-ZÅÄÖa-zåäö#&/][A-ZÅÄÖa-zåäö0-9/,.:!=\-\[\]]*[0-9]| TX| RX){8,8} ', text) or
 
         # Sequences of URIs have led to excessive consumption. This is
         # blocking rather short such. (Was this the case where memory
         # consumption went through the roof? Or was this just time?)
-        re.search('( (http|https|ftp)://\S+){5,5} ', text) or
+        re.search(r'( (http|https|ftp)://\S+){5,5} ', text) or
 
         # A long sequences of /REDACTED/ tokens was observed to cause
         # problems where the originally repeated over-long token
         # probably would not have contained capital letters at all.
         # (The token actually ends in digits, which may the issue.)
         # (But should be no harm in blocking /REDACTED/ sequences.)
-        re.search('( \S*/REDACTED/\S*){10,10} ', text) or
+        re.search(r'( \S*/REDACTED/\S*){10,10} ', text) or
 
         # finnish-nertag (version 1.6, --no-tokenize) eats _#_
         # altogether, which must be considered a bug in the tool

--- a/vrt-tools/libvrt/tools/vrt_guess_lang.py
+++ b/vrt-tools/libvrt/tools/vrt_guess_lang.py
@@ -28,7 +28,7 @@ except ImportError as exn:
     print('Import Error:', exn, file = sys.stderr)
 
 def _name(arg):
-    if re.fullmatch('\w+', arg, re.ASCII):
+    if re.fullmatch(r'\w+', arg, re.ASCII):
         return arg.encode('UTF-8')
     raise ArgumentTypeError('bad name: ' + repr(arg))
 
@@ -127,7 +127,7 @@ def pr1_test(*, meta = (), tags = ()):
 
     '''
     for line in chain(meta, tags):
-        atts = b'\t'.join(re.findall(b'\S+=".*?"', line)) + b'\n'
+        atts = b'\t'.join(re.findall(br'\S+=".*?"', line)) + b'\n'
         if atts: atts = b'\t' + atts
         if line.startswith((b'<text>', b'<text ')):
             META['text'] = b'text' + atts

--- a/vrt-tools/libvrt/tools/vrt_id_sent_lang.py
+++ b/vrt-tools/libvrt/tools/vrt_id_sent_lang.py
@@ -135,7 +135,7 @@ def pr1_test(*, meta = (), tags = ()):
 
     '''
     for line in chain(meta, tags):
-        atts = b'\t'.join(re.findall(b'\S+=".*?"', line)) + b'\n'
+        atts = b'\t'.join(re.findall(br'\S+=".*?"', line)) + b'\n'
         if atts: atts = b'\t' + atts
         if line.startswith((b'<text>', b'<text ')):
             META['text'] = b'text' + atts

--- a/vrt-tools/libvrt/tools/vrt_set_sentence_polarity.py
+++ b/vrt-tools/libvrt/tools/vrt_set_sentence_polarity.py
@@ -17,7 +17,7 @@ from libvrt.bad import BadData, BadCode
 from libvrt.pr1 import transput
 
 def _name(arg):
-    if re.fullmatch('\w+', arg, re.ASCII):
+    if re.fullmatch(r'\w+', arg, re.ASCII):
         return arg.encode('UTF-8')
     raise ArgumentTypeError('bad name: ' + repr(arg))
 

--- a/vrt-tools/libvrt/tools/vrt_sort.py
+++ b/vrt-tools/libvrt/tools/vrt_sort.py
@@ -147,7 +147,7 @@ class VrtSorter(InputProcessor):
         self._transform_attrs = set(self._transform_funcs.keys())
 
     def _make_transforms(self, transforms):
-        attrname_re = re.compile('\s*([\w-]+)\s*:\s*')
+        attrname_re = re.compile(r'\s*([\w-]+)\s*:\s*')
         for transform in transforms:
             mo = attrname_re.match(transform)
             if mo:

--- a/vrt-tools/tests/tools/test_vrt_finnish_nertag.py
+++ b/vrt-tools/tests/tools/test_vrt_finnish_nertag.py
@@ -103,7 +103,7 @@ def test_defaults():
     for line in sent1:
         assert line.count('\t') == 3
         sen, ref, word, tag = line.split('\t')
-        assert re.fullmatch('\|([^\|]+\|)*', tag)
+        assert re.fullmatch(r'\|([^\|]+\|)*', tag)
 
     # SENT2 should be all | because _skip="|finnish-nertag|"
     sent2 = [ line for line in ouf if line.startswith('SENT2') ]
@@ -159,7 +159,7 @@ def test_ne_markup():
     for line in sent2:
         assert line.count('\t') == 3
         sen, ref, word, tag = line.split('\t')
-        assert re.fullmatch('\|([^\|]+\|)*', tag)
+        assert re.fullmatch(r'\|([^\|]+\|)*', tag)
 
 @have_finnish_nertag
 def test_middle_skip():

--- a/vrt-tools/vrt-decode-tags
+++ b/vrt-tools/vrt-decode-tags
@@ -97,7 +97,7 @@ class TagDecoder(InputProcessor):
         # space or end-of-string (a tag).
         ignore_re = re.compile(
             ((r'((?<= \S) (?:' + args.hyphens + ')+ )?'
-              + '(?: \Z | (?:' + args.spaces + ')+)')
+              + r'(?: \Z | (?:' + args.spaces + ')+)')
              if args.hyphens else
              ('(?:' + args.spaces + ')+')),
             re.VERBOSE)

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -604,7 +604,7 @@ IDENTIFY_C1_CP1252 = str.maketrans({
     '\x86' : '{C1:cp1252:\N{DAGGER}}',
 
     # U+0087 C1 ESA => U+2021 ‡
-    '\x87' : '{C1:cp1252:\{DOUBLE DAGGER}}',
+    '\x87' : '{C1:cp1252:\N{DOUBLE DAGGER}}',
 
     # U+0088 C1 HTS => U+02c6 ˆ
     '\x88' : '{C1:cp1252:\N{MODIFIER LETTER CIRCUMFLEX ACCENT}}',
@@ -704,7 +704,7 @@ ABUSE_C1_CP1252 = str.maketrans({
     '\x86' : '\N{DAGGER}',
 
     # U+0087 C1 ESA => U+2021 ‡
-    '\x87' : '\{DOUBLE DAGGER}',
+    '\x87' : '\N{DOUBLE DAGGER}',
 
     # U+0088 C1 HTS => U+02c6 ˆ
     '\x88' : '\N{MODIFIER LETTER CIRCUMFLEX ACCENT}',

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -251,7 +251,7 @@ def fixdata(args, value):
     return value
 
 def unbreakity(match, quote = False):
-    '''Consider any &\w+; an attempted named entity (ASCII only), also
+    '''Consider any &\\w+; an attempted named entity (ASCII only), also
     consider any numerical-looking entity up to and including the
     semicolon, and actually consider any string of such up to and
     including a semicolon - type "&lt&lt&lt;" that complicators of

--- a/vrt-tools/vrt-fix-characters
+++ b/vrt-tools/vrt-fix-characters
@@ -652,10 +652,10 @@ IDENTIFY_C1_CP1252 = str.maketrans({
     '\x96' : '{C1:cp1252:\N{EN DASH}}',
 
     # U+0097 C1 EPA => U+2014 —
-    '\x97' : '{C1:cp1252:\N{EM DASH}})',
+    '\x97' : '{C1:cp1252:\N{EM DASH}}',
 
     # U+0098 C1 SOS => U+02dc ˜
-    '\x98' : '{C1:cp1252\N{SMALL TILDE}}',
+    '\x98' : '{C1:cp1252:\N{SMALL TILDE}}',
 
     # U+0099 C1 SGCI => U+2122 ™
     '\x99' : '{C1:cp1252:\N{TRADE MARK SIGN}}',
@@ -755,7 +755,7 @@ ABUSE_C1_CP1252 = str.maketrans({
     '\x97' : '\N{EM DASH}',
 
     # U+0098 C1 SOS => U+02dc ˜
-    '\x98' : '{C1:cp1252\N{SMALL TILDE}',
+    '\x98' : '\N{SMALL TILDE}',
 
     # U+0099 C1 SGCI => U+2122 ™
     '\x99' : '\N{TRADE MARK SIGN}',

--- a/vrt-tools/vrt-rm-structs
+++ b/vrt-tools/vrt-rm-structs
@@ -95,7 +95,7 @@ class StructureRemover(InputProcessor):
                 else:
                     return mo.group()
 
-            attr_regex = re.sub('\.', repl_fullstop, attr_regex)
+            attr_regex = re.sub(r'\.', repl_fullstop, attr_regex)
             # print(attr_regex, file=sys.stderr)
             return re.compile(' ' + attr_regex)
 


### PR DESCRIPTION
Fix strings with invalid backslash escape sequences to be raw strings (or double the backslash), as Python 3.12 and newer emit a `SyntaxWarning` about them, instead of silently treating the backslash literally. These strings are typically regular expressions that should be raw strings.